### PR TITLE
[codex] add Bytes runtime write path

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1367,17 +1367,34 @@ Runtime boundary integer and pointer conventions:
 - lengths/counts: `USize`
 - read/write byte count returns: `ISize`
 - file offsets: `Int64`
-- raw pointers: `Ptr[T]`
-- raw spans: `Slice[T]`
+- opaque runtime byte buffers: `Bytes`
 
-`Slice[T]` is the canonical pair shape:
+`Bytes` is the current kernel-facing buffer type. It is an owned opaque runtime object with:
+
+- `len: USize`
+- contiguous mutable byte storage
+
+The public builtin surface for byte-oriented host I/O is:
 
 ```aura
-def[T] Slice = (ptr: Ptr[T], len: USize);
+syscall_write(fd: Int32, bytes: Bytes) -> ISize
+
+Bytes.new(size: USize) -> Bytes
+Bytes.get(self: Bytes, index: USize) -> UInt8
+Bytes.set(self: Bytes, index: USize, value: UInt8) -> Void
+
+String.into(self: String) -> Bytes
 ```
 
-Kernel builtins remain low-level (`Ptr`/`Slice` + fixed-width ints); STL layers provide
-typed ergonomic wrappers (`String`, `List[UInt8]`, `Array[UInt8, N]`) on top.
+`syscall_write` writes the contents of `bytes` to the host file descriptor and returns the number
+of bytes written. The current host implementation recognizes `1` as stdout and `2` as stderr; it
+returns `-1` on host write failure.
+
+`Bytes.get` and `Bytes.set` are intentionally unchecked for now. Out-of-bounds access is undefined
+behavior until panic handlers exist.
+
+`String` remains the public string-literal type; converting it to a writeable buffer requires
+`String.into()`, which copies the UTF-8 bytes into a fresh owned `Bytes` value.
 
 ---
 

--- a/crates/aura-codegen/src/llvm/expr.rs
+++ b/crates/aura-codegen/src/llvm/expr.rs
@@ -345,10 +345,18 @@ fn runtime_builtin_function_type<'ctx, 'm>(
     name: &str,
 ) -> Option<inkwell::types::FunctionType<'ctx>> {
     let i32_ty = cg.context.i32_type();
+    let i64_ty = cg.context.i64_type();
+    let i8_ty = cg.context.i8_type();
+    let ptr_ty = cg.context.ptr_type(AddressSpace::default());
     let void_ty = cg.context.void_type();
 
     let ty = match name {
         "syscall_exit" => void_ty.fn_type(&[i32_ty.into()], false),
+        "syscall_write" => i64_ty.fn_type(&[i32_ty.into(), ptr_ty.into()], false),
+        "bytes_new" => ptr_ty.fn_type(&[i64_ty.into()], false),
+        "bytes_get" => i8_ty.fn_type(&[ptr_ty.into(), i64_ty.into()], false),
+        "bytes_set" => void_ty.fn_type(&[ptr_ty.into(), i64_ty.into(), i8_ty.into()], false),
+        "string_into" => ptr_ty.fn_type(&[ptr_ty.into()], false),
         _ => return None,
     };
     Some(ty)

--- a/crates/aura-codegen/src/llvm/module.rs
+++ b/crates/aura-codegen/src/llvm/module.rs
@@ -333,6 +333,38 @@ mod tests {
 
     #[cfg(feature = "llvm-backend")]
     #[test]
+    fn object_emission_supports_syscall_write_with_string_into() {
+        let src =
+            "def main() -> Void { syscall_write(1, \"Hello, world!\".into()); syscall_exit(0) }";
+        let program = Parser::parse_source(src).expect("parse");
+        let checked = check_module(&program);
+        let module = checked.module.expect("checked module");
+        let out = std::env::temp_dir().join("aura-main-hello-world.obj");
+        super::emit_object_file("main_hello_world", &module, &out).expect("emit object");
+        assert!(out.exists());
+        let _ = std::fs::remove_file(out);
+    }
+
+    #[cfg(feature = "llvm-backend")]
+    #[test]
+    fn llvm_ir_declares_runtime_bytes_and_write_symbols() {
+        let src =
+            "def main() -> Void { syscall_write(1, \"Hello, world!\".into()); syscall_exit(0) }";
+        let program = Parser::parse_source(src).expect("parse");
+        let checked = check_module(&program);
+        let module = checked.module.expect("checked module");
+
+        let ir = super::emit_module_stub("main_hello_world", &module).expect("emit ir");
+
+        assert!(ir.contains("declare i64 @syscall_write(i32, ptr)"));
+        assert!(ir.contains("declare ptr @string_into(ptr)"));
+        assert!(ir.contains("declare void @syscall_exit(i32)"));
+        assert!(ir.contains("call ptr @string_into(ptr"));
+        assert!(ir.contains("call i64 @syscall_write(i32 1, ptr"));
+    }
+
+    #[cfg(feature = "llvm-backend")]
+    #[test]
     fn non_void_main_is_rejected_before_codegen() {
         let src = "def main() -> Result[Void, UInt8] { .err(7) }";
         let program = Parser::parse_source(src).expect("parse");

--- a/crates/aura-codegen/src/llvm/types.rs
+++ b/crates/aura-codegen/src/llvm/types.rs
@@ -53,8 +53,6 @@ pub fn classify_type(types: &TyInterner, ty_id: TyId) -> Result<AuraValueType, C
         }
         Ty::Never
         | Ty::Any
-        | Ty::Ptr(_)
-        | Ty::Slice(_)
         | Ty::Nominal(_)
         | Ty::List(_)
         | Ty::Dict { .. }

--- a/crates/aura-diagnostics/src/type_ref.rs
+++ b/crates/aura-diagnostics/src/type_ref.rs
@@ -28,8 +28,6 @@ pub enum TypeRef {
     Primitive(PrimitiveType),
     InferVar(u32),
     GenericParam(String),
-    Ptr(Box<TypeRef>),
-    Slice(Box<TypeRef>),
     Nominal(String),
     List(Box<TypeRef>),
     Dict {
@@ -85,8 +83,6 @@ impl fmt::Display for TypeRef {
             Self::Primitive(p) => write!(f, "{p}"),
             Self::InferVar(v) => write!(f, "_t{v}"),
             Self::GenericParam(name) => f.write_str(name),
-            Self::Ptr(inner) => write!(f, "Ptr[{inner}]"),
-            Self::Slice(inner) => write!(f, "Slice[{inner}]"),
             Self::Nominal(name) => f.write_str(name),
             Self::List(item) => write!(f, "List[{item}]"),
             Self::Dict { key, value } => write!(f, "Dict[{key}, {value}]"),

--- a/crates/aura-runtime-host/src/lib.rs
+++ b/crates/aura-runtime-host/src/lib.rs
@@ -1,4 +1,152 @@
+use std::io::Write;
+
+pub struct AuraBytes {
+    len: usize,
+    storage: Vec<u8>,
+}
+
+impl AuraBytes {
+    fn new_zeroed(size: usize) -> Self {
+        Self {
+            len: size,
+            storage: vec![0; size],
+        }
+    }
+
+    fn from_storage(storage: Vec<u8>) -> Self {
+        Self {
+            len: storage.len(),
+            storage,
+        }
+    }
+}
+
+unsafe fn bytes_ref<'a>(bytes: *const AuraBytes) -> &'a AuraBytes {
+    // The Aura runtime treats `Bytes` as an opaque owned pointer.
+    unsafe { &*bytes }
+}
+
+unsafe fn bytes_mut<'a>(bytes: *mut AuraBytes) -> &'a mut AuraBytes {
+    // Bounds checks are intentionally absent for now; callers own the UB contract.
+    unsafe { &mut *bytes }
+}
+
+unsafe fn c_string_len(mut ptr: *const u8) -> usize {
+    let mut len = 0usize;
+    while unsafe { *ptr } != 0 {
+        len += 1;
+        ptr = unsafe { ptr.add(1) };
+    }
+    len
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn bytes_new(size: usize) -> *mut AuraBytes {
+    Box::into_raw(Box::new(AuraBytes::new_zeroed(size)))
+}
+
+#[unsafe(no_mangle)]
+/// # Safety
+/// `bytes` must point to a valid `AuraBytes`, and `index` must be in bounds.
+pub unsafe extern "C" fn bytes_get(bytes: *const AuraBytes, index: usize) -> u8 {
+    unsafe { bytes_ref(bytes).storage[index] }
+}
+
+#[unsafe(no_mangle)]
+/// # Safety
+/// `bytes` must point to a valid `AuraBytes`, and `index` must be in bounds.
+pub unsafe extern "C" fn bytes_set(bytes: *mut AuraBytes, index: usize, value: u8) {
+    unsafe {
+        bytes_mut(bytes).storage[index] = value;
+    }
+}
+
+#[unsafe(no_mangle)]
+/// # Safety
+/// `string` must be a valid NUL-terminated UTF-8 byte sequence.
+pub unsafe extern "C" fn string_into(string: *const u8) -> *mut AuraBytes {
+    let len = unsafe { c_string_len(string) };
+    let storage = unsafe { std::slice::from_raw_parts(string, len) }.to_vec();
+    Box::into_raw(Box::new(AuraBytes::from_storage(storage)))
+}
+
+#[unsafe(no_mangle)]
+/// # Safety
+/// `bytes` must point to a valid `AuraBytes`.
+pub unsafe extern "C" fn syscall_write(fd: i32, bytes: *const AuraBytes) -> isize {
+    let bytes = unsafe { bytes_ref(bytes) };
+    let result = match fd {
+        1 => {
+            let mut stdout = std::io::stdout().lock();
+            stdout
+                .write_all(&bytes.storage)
+                .and_then(|_| stdout.flush())
+                .map(|_| bytes.len as isize)
+        }
+        2 => {
+            let mut stderr = std::io::stderr().lock();
+            stderr
+                .write_all(&bytes.storage)
+                .and_then(|_| stderr.flush())
+                .map(|_| bytes.len as isize)
+        }
+        _ => return -1,
+    };
+
+    result.unwrap_or(-1)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn syscall_exit(code: i32) -> ! {
     std::process::exit(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AuraBytes, bytes_get, bytes_new, bytes_set, string_into, syscall_write};
+
+    #[test]
+    fn bytes_new_allocates_zeroed_storage() {
+        let bytes = bytes_new(4);
+        let bytes = unsafe { &*bytes };
+        assert_eq!(bytes.len, 4);
+        assert_eq!(bytes.storage, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn bytes_get_and_set_round_trip_a_value() {
+        let bytes = bytes_new(2);
+        unsafe {
+            bytes_set(bytes, 1, 65);
+            assert_eq!(bytes_get(bytes, 1), 65);
+        }
+    }
+
+    #[test]
+    fn string_into_copies_utf8_bytes_into_owned_storage() {
+        let source = b"Hello, world!\0";
+        let bytes = unsafe { string_into(source.as_ptr()) };
+        let bytes = unsafe { &*bytes };
+        assert_eq!(bytes.len, 13);
+        assert_eq!(bytes.storage, b"Hello, world!");
+    }
+
+    #[test]
+    fn syscall_write_returns_byte_count_for_stdout_and_stderr() {
+        let stdout_bytes = Box::into_raw(Box::new(AuraBytes::from_storage(b"out".to_vec())));
+        let stderr_bytes = Box::into_raw(Box::new(AuraBytes::from_storage(b"err".to_vec())));
+
+        let stdout_written = unsafe { syscall_write(1, stdout_bytes) };
+        let stderr_written = unsafe { syscall_write(2, stderr_bytes) };
+
+        assert_eq!(stdout_written, 3);
+        assert_eq!(stderr_written, 3);
+    }
+
+    #[test]
+    fn syscall_write_returns_negative_one_for_invalid_fd() {
+        let bytes = Box::into_raw(Box::new(AuraBytes::from_storage(b"oops".to_vec())));
+        let written = unsafe { syscall_write(99, bytes) };
+        assert_eq!(written, -1);
+    }
 }

--- a/crates/aura-typecheck/src/builtins.rs
+++ b/crates/aura-typecheck/src/builtins.rs
@@ -3,6 +3,12 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BuiltinTypeRef {
     Int32,
+    ISize,
+    USize,
+    UInt8,
+    Void,
+    Bytes,
+    String,
     Never,
 }
 
@@ -30,11 +36,23 @@ impl BuiltinRegistry {
                 ret: BuiltinTypeRef::Never,
             },
         );
+        entries.insert(
+            "syscall_write".to_string(),
+            BuiltinSignature {
+                name: "syscall_write".to_string(),
+                params: vec![BuiltinTypeRef::Int32, BuiltinTypeRef::Bytes],
+                ret: BuiltinTypeRef::ISize,
+            },
+        );
         Self { entries }
     }
 
     pub fn get(&self, name: &str) -> Option<&BuiltinSignature> {
         self.entries.get(name)
+    }
+
+    pub fn signatures(&self) -> impl Iterator<Item = &BuiltinSignature> {
+        self.entries.values()
     }
 }
 
@@ -46,13 +64,28 @@ impl Default for BuiltinRegistry {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::BuiltinRegistry;
+    use crate::builtins::{BuiltinRegistry, BuiltinTypeRef};
 
     #[test]
     fn prelude_registry_contains_expected_builtins() {
         let registry = BuiltinRegistry::with_prelude();
         assert!(registry.get("syscall_exit").is_some());
+        assert!(registry.get("syscall_write").is_some());
         assert!(registry.get("rt_exit").is_none());
         assert!(registry.get("missing_builtin").is_none());
+    }
+
+    #[test]
+    fn syscall_write_signature_uses_fd_and_bytes_abi() {
+        let registry = BuiltinRegistry::with_prelude();
+        let write = registry
+            .get("syscall_write")
+            .expect("syscall_write must exist");
+
+        assert_eq!(
+            write.params,
+            vec![BuiltinTypeRef::Int32, BuiltinTypeRef::Bytes]
+        );
+        assert_eq!(write.ret, BuiltinTypeRef::ISize);
     }
 }

--- a/crates/aura-typecheck/src/checker.rs
+++ b/crates/aura-typecheck/src/checker.rs
@@ -103,6 +103,14 @@ enum ConversionDecision {
     Incompatible,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuiltinMemberCall {
+    BytesNew,
+    BytesGet,
+    BytesSet,
+    StringInto,
+}
+
 #[derive(Debug, Clone)]
 struct FunctionGenericInfo {
     name: String,
@@ -139,7 +147,7 @@ impl TypeChecker {
             options,
         };
 
-        if let Some(sig) = checker.builtins.get("syscall_exit").cloned() {
+        for sig in checker.builtins.signatures().cloned().collect::<Vec<_>>() {
             let param_tys = sig
                 .params
                 .iter()
@@ -150,7 +158,7 @@ impl TypeChecker {
                 params: param_tys,
                 ret,
             });
-            checker.insert_value("syscall_exit".to_string(), func_ty, false);
+            checker.insert_value(sig.name, func_ty, false);
         }
 
         checker
@@ -166,6 +174,142 @@ impl TypeChecker {
 
     fn is_placeholder_expr(expr: &Expr) -> bool {
         matches!(Self::base_expr(expr), Expr::Placeholder)
+    }
+
+    fn nominal_ty(&mut self, name: &str) -> TyId {
+        self.interner.intern(Ty::Nominal(name.to_string()))
+    }
+
+    fn classify_builtin_member_call(object: &Expr, field: &str) -> Option<BuiltinMemberCall> {
+        match (Self::base_expr(object), field) {
+            (Expr::Ident(name), "new") if name == "Bytes" => Some(BuiltinMemberCall::BytesNew),
+            (_, "get") => Some(BuiltinMemberCall::BytesGet),
+            (_, "set") => Some(BuiltinMemberCall::BytesSet),
+            (_, "into") => Some(BuiltinMemberCall::StringInto),
+            _ => None,
+        }
+    }
+
+    fn emit_builtin_method_arity_error(&mut self, name: &str, expected: usize, actual: usize) {
+        self.diagnostics.push(
+            self.typecheck_error(
+                Issue::BuiltinForm,
+                format!(
+                    "builtin method '{name}' expects {expected} runtime arguments, got {actual}"
+                ),
+            )
+            .with_hint("adjust the runtime argument count to match the builtin method"),
+        );
+    }
+
+    fn infer_builtin_member_call(
+        &mut self,
+        object: &Expr,
+        field: &str,
+        args: &[Expr],
+        trailing: &[LabeledClosureArg],
+        expected_ret: Option<TyId>,
+    ) -> Option<TyId> {
+        let kind = Self::classify_builtin_member_call(object, field)?;
+        if !trailing.is_empty() {
+            self.diagnostics.push(
+                self.typecheck_error(
+                    Issue::BuiltinForm,
+                    format!("builtin method '{field}' does not accept trailing closures"),
+                )
+                .with_hint("pass only positional runtime arguments to this builtin method"),
+            );
+            return Some(self.unknown_ty());
+        }
+
+        let usize_ty = self.interner.intern(Ty::USize);
+        let uint8_ty = self.interner.intern(Ty::UInt8);
+        let void_ty = self.interner.intern(Ty::Void);
+        let bytes_ty = self.nominal_ty("Bytes");
+        let string_ty = self.nominal_ty("String");
+
+        let actual = match kind {
+            BuiltinMemberCall::BytesNew => {
+                if args.len() != 1 {
+                    self.emit_builtin_method_arity_error("Bytes.new", 1, args.len());
+                    return Some(self.unknown_ty());
+                }
+                let size_ty = self.infer_expr_with_expected(&args[0], usize_ty);
+                self.require_assignable(usize_ty, size_ty, "Bytes.new size");
+                bytes_ty
+            }
+            BuiltinMemberCall::BytesGet => {
+                if args.len() != 1 {
+                    self.emit_builtin_method_arity_error("Bytes.get", 1, args.len());
+                    return Some(self.unknown_ty());
+                }
+                let receiver_ty = self.infer_expr(object);
+                self.require_assignable(bytes_ty, receiver_ty, "Bytes.get receiver");
+                let index_ty = self.infer_expr_with_expected(&args[0], usize_ty);
+                self.require_assignable(usize_ty, index_ty, "Bytes.get index");
+                uint8_ty
+            }
+            BuiltinMemberCall::BytesSet => {
+                if args.len() != 2 {
+                    self.emit_builtin_method_arity_error("Bytes.set", 2, args.len());
+                    return Some(self.unknown_ty());
+                }
+                let receiver_ty = self.infer_expr(object);
+                self.require_assignable(bytes_ty, receiver_ty, "Bytes.set receiver");
+                let index_ty = self.infer_expr_with_expected(&args[0], usize_ty);
+                self.require_assignable(usize_ty, index_ty, "Bytes.set index");
+                let value_ty = self.infer_expr_with_expected(&args[1], uint8_ty);
+                self.require_assignable(uint8_ty, value_ty, "Bytes.set value");
+                void_ty
+            }
+            BuiltinMemberCall::StringInto => {
+                if !args.is_empty() {
+                    self.emit_builtin_method_arity_error("String.into", 0, args.len());
+                    return Some(self.unknown_ty());
+                }
+                let receiver_ty = self.infer_expr(object);
+                self.require_assignable(string_ty, receiver_ty, "String.into receiver");
+                bytes_ty
+            }
+        };
+
+        if let Some(expected) = expected_ret {
+            self.require_assignable(expected, actual, "builtin method return");
+        }
+
+        Some(actual)
+    }
+
+    fn lower_builtin_member_call(
+        &mut self,
+        object: &Expr,
+        field: &str,
+        args: &[Expr],
+    ) -> Option<CheckedExpr> {
+        let kind = Self::classify_builtin_member_call(object, field)?;
+        let (name, lowered_args): (&str, Vec<CheckedExpr>) = match kind {
+            BuiltinMemberCall::BytesNew => {
+                ("bytes_new", args.iter().map(|arg| self.lower_expr(arg)).collect())
+            }
+            BuiltinMemberCall::BytesGet => (
+                "bytes_get",
+                std::iter::once(self.lower_expr(object))
+                    .chain(args.iter().map(|arg| self.lower_expr(arg)))
+                    .collect(),
+            ),
+            BuiltinMemberCall::BytesSet => (
+                "bytes_set",
+                std::iter::once(self.lower_expr(object))
+                    .chain(args.iter().map(|arg| self.lower_expr(arg)))
+                    .collect(),
+            ),
+            BuiltinMemberCall::StringInto => ("string_into", vec![self.lower_expr(object)]),
+        };
+
+        Some(CheckedExpr::Call {
+            callee: Box::new(CheckedExpr::Ident(name.to_string())),
+            args: lowered_args,
+        })
     }
 
     fn pipe_to_call_expr(lhs: &Expr, rhs: &Expr) -> Expr {
@@ -549,6 +693,13 @@ impl TypeChecker {
                 trailing,
                 ..
             } => {
+                if let Expr::Member { object, field } = TypeChecker::base_expr(callee.as_ref()) {
+                    if let Some(ret) =
+                        self.infer_builtin_member_call(object, field, args, trailing, None)
+                    {
+                        return ret;
+                    }
+                }
                 let callee_name = match TypeChecker::base_expr(callee.as_ref()) {
                     Expr::Ident(name) => Some(name.clone()),
                     _ => None,
@@ -859,12 +1010,20 @@ impl TypeChecker {
                 Expr::Call {
                     callee,
                     static_args,
-                    args,
-                    trailing,
-                    ..
+                args,
+                trailing,
+                ..
                 },
                 _,
             ) => {
+                if let Expr::Member { object, field } = TypeChecker::base_expr(callee.as_ref()) {
+                    if let Some(actual) = self
+                        .infer_builtin_member_call(object, field, args, trailing, Some(expected))
+                    {
+                        self.require_assignable(expected, actual, "bidirectional expected type");
+                        return actual;
+                    }
+                }
                 let callee_name = match TypeChecker::base_expr(callee.as_ref()) {
                     Expr::Ident(name) => Some(name.clone()),
                     _ => None,
@@ -948,6 +1107,42 @@ impl TypeChecker {
                             "integer literal is out of range for UInt8",
                         )
                         .with_hint("use a value between 0 and 255 for UInt8"),
+                    );
+                    self.unknown_ty()
+                }
+            }
+            (Expr::Int(value), Some(Ty::USize)) => {
+                if value.parse::<usize>().is_ok() {
+                    expected
+                } else {
+                    self.diagnostics.push(
+                        self.typecheck_error(
+                            Issue::TypeMismatch {
+                                context: TypingContext::Custom("integer literal".to_string()),
+                                expected: TypeRef::Primitive(PrimitiveType::USize),
+                                actual: TypeRef::Primitive(PrimitiveType::Int32),
+                            },
+                            "integer literal is out of range for USize",
+                        )
+                        .with_hint("use a non-negative integer that fits in the target pointer width"),
+                    );
+                    self.unknown_ty()
+                }
+            }
+            (Expr::Int(value), Some(Ty::ISize)) => {
+                if value.parse::<isize>().is_ok() {
+                    expected
+                } else {
+                    self.diagnostics.push(
+                        self.typecheck_error(
+                            Issue::TypeMismatch {
+                                context: TypingContext::Custom("integer literal".to_string()),
+                                expected: TypeRef::Primitive(PrimitiveType::ISize),
+                                actual: TypeRef::Primitive(PrimitiveType::Int32),
+                            },
+                            "integer literal is out of range for ISize",
+                        )
+                        .with_hint("use an integer that fits in the target pointer width"),
                     );
                     self.unknown_ty()
                 }
@@ -1215,6 +1410,12 @@ impl TypeChecker {
     fn intern_builtin_type(&mut self, ty: &BuiltinTypeRef) -> TyId {
         match ty {
             BuiltinTypeRef::Int32 => self.interner.intern(Ty::Int32),
+            BuiltinTypeRef::ISize => self.interner.intern(Ty::ISize),
+            BuiltinTypeRef::USize => self.interner.intern(Ty::USize),
+            BuiltinTypeRef::UInt8 => self.interner.intern(Ty::UInt8),
+            BuiltinTypeRef::Void => self.interner.intern(Ty::Void),
+            BuiltinTypeRef::Bytes => self.nominal_ty("Bytes"),
+            BuiltinTypeRef::String => self.nominal_ty("String"),
             BuiltinTypeRef::Never => self.interner.intern(Ty::Never),
         }
     }
@@ -1608,19 +1809,13 @@ impl TypeChecker {
                         self.enforce_exact_type_arity("Any", args, 0);
                         self.interner.intern(Ty::Any)
                     }
-                    "Ptr" => {
-                        self.enforce_exact_type_arity("Ptr", args, 1);
-                        let item = self.resolve_required_type_arg(args, 0, "Ptr", "item");
-                        self.interner.intern(Ty::Ptr(item))
-                    }
-                    "Slice" => {
-                        self.enforce_exact_type_arity("Slice", args, 1);
-                        let item = self.resolve_required_type_arg(args, 0, "Slice", "item");
-                        self.interner.intern(Ty::Slice(item))
+                    "Bytes" => {
+                        self.enforce_exact_type_arity("Bytes", args, 0);
+                        self.nominal_ty("Bytes")
                     }
                     "String" => {
                         self.enforce_exact_type_arity("String", args, 0);
-                        self.interner.intern(Ty::Nominal("String".to_string()))
+                        self.nominal_ty("String")
                     }
                     "List" => {
                         self.enforce_exact_type_arity("List", args, 1);
@@ -2071,14 +2266,6 @@ impl TypeChecker {
                 .get(&name)
                 .copied()
                 .unwrap_or_else(|| self.interner.intern(Ty::GenericParam(name))),
-            Ty::Ptr(item) => {
-                let i = self.substitute_ty_id(item, subst);
-                self.interner.intern(Ty::Ptr(i))
-            }
-            Ty::Slice(item) => {
-                let i = self.substitute_ty_id(item, subst);
-                self.interner.intern(Ty::Slice(i))
-            }
             Ty::Nominal(name) => subst
                 .get(&name)
                 .copied()
@@ -2455,10 +2642,7 @@ impl TypeChecker {
                     | Ty::Nominal(_)
             ),
             "Iterable" => matches!(ty, Ty::List(_) | Ty::Array { .. } | Ty::Set(_)),
-            "From" => matches!(
-                ty,
-                Ty::Func { .. } | Ty::Nominal(_) | Ty::Ptr(_) | Ty::Slice(_)
-            ),
+            "From" => matches!(ty, Ty::Func { .. } | Ty::Nominal(_)),
             _ => false,
         }
     }
@@ -2592,9 +2776,7 @@ impl TypeChecker {
         };
 
         match (expected_ty, actual_ty) {
-            (Ty::Ptr(a), Ty::Ptr(b))
-            | (Ty::Slice(a), Ty::Slice(b))
-            | (Ty::List(a), Ty::List(b)) => self.structurally_equivalent(*a, *b),
+            (Ty::List(a), Ty::List(b)) => self.structurally_equivalent(*a, *b),
             (Ty::Dict { key: ak, value: av }, Ty::Dict { key: bk, value: bv }) => {
                 self.structurally_equivalent(*ak, *bk) && self.structurally_equivalent(*av, *bv)
             }
@@ -2911,10 +3093,17 @@ impl TypeChecker {
                     .map(|(k, v)| (self.lower_expr(k), self.lower_expr(v)))
                     .collect(),
             ),
-            Expr::Call { callee, args, .. } => CheckedExpr::Call {
-                callee: Box::new(self.lower_expr(callee)),
-                args: args.iter().map(|a| self.lower_expr(a)).collect(),
-            },
+            Expr::Call { callee, args, .. } => {
+                if let Expr::Member { object, field } = TypeChecker::base_expr(callee.as_ref()) {
+                    if let Some(lowered) = self.lower_builtin_member_call(object, field, args) {
+                        return lowered;
+                    }
+                }
+                CheckedExpr::Call {
+                    callee: Box::new(self.lower_expr(callee)),
+                    args: args.iter().map(|a| self.lower_expr(a)).collect(),
+                }
+            }
             Expr::MacroApply {
                 macro_name,
                 operand,
@@ -3311,20 +3500,6 @@ fn ty_to_ref(ty: &Ty, interner: &TyInterner) -> TypeRef {
         Ty::Void => TypeRef::Primitive(PrimitiveType::Void),
         Ty::Never => TypeRef::Primitive(PrimitiveType::Never),
         Ty::Any => TypeRef::Primitive(PrimitiveType::Any),
-        Ty::Ptr(item) => {
-            let item_ref = interner
-                .get(*item)
-                .map(|t| ty_to_ref(t, interner))
-                .unwrap_or(TypeRef::Unknown);
-            TypeRef::Ptr(Box::new(item_ref))
-        }
-        Ty::Slice(item) => {
-            let item_ref = interner
-                .get(*item)
-                .map(|t| ty_to_ref(t, interner))
-                .unwrap_or(TypeRef::Unknown);
-            TypeRef::Slice(Box::new(item_ref))
-        }
         Ty::Nominal(name) => TypeRef::Nominal(name.clone()),
         Ty::List(item) => {
             let item_ref = interner
@@ -6252,6 +6427,65 @@ mod tests {
             "expected module, got diagnostics: {:?}",
             checked.diagnostics
         );
+    }
+
+    #[test]
+    fn bytes_new_and_get_calls_typecheck() {
+        let program = Parser::parse_source("def b = Bytes.new(4); def x = b.get(0)")
+            .expect("source should parse");
+
+        let checked = check_module(&program);
+        assert!(
+            checked.module.is_some(),
+            "expected module, got diagnostics: {:?}",
+            checked.diagnostics
+        );
+
+        let module = checked.module.expect("module should exist");
+        let b_ty = module.value_types.get("b").expect("b should exist");
+        let x_ty = module.value_types.get("x").expect("x should exist");
+        assert!(matches!(module.types.get(*b_ty), Some(Ty::Nominal(name)) if name == "Bytes"));
+        assert!(matches!(module.types.get(*x_ty), Some(Ty::UInt8)));
+    }
+
+    #[test]
+    fn bytes_set_returns_void() {
+        let program = Parser::parse_source("def v = { let b = Bytes.new(1); b.set(0, 65) }")
+            .expect("source should parse");
+
+        let checked = check_module(&program);
+        assert!(
+            checked.module.is_some(),
+            "expected module, got diagnostics: {:?}",
+            checked.diagnostics
+        );
+
+        let module = checked.module.expect("module should exist");
+        let v_ty = module.value_types.get("v").expect("v should exist");
+        assert!(matches!(module.types.get(*v_ty), Some(Ty::Void)));
+    }
+
+    #[test]
+    fn string_into_and_syscall_write_typecheck() {
+        let program =
+            Parser::parse_source("def main() -> Void { syscall_write(1, \"Hello\".into()); syscall_exit(0) }")
+                .expect("source should parse");
+
+        let checked = check_module(&program);
+        assert!(
+            checked.module.is_some(),
+            "expected module, got diagnostics: {:?}",
+            checked.diagnostics
+        );
+
+        let module = checked.module.expect("module should exist");
+        let main_decl = module
+            .ir
+            .declarations
+            .iter()
+            .find(|decl| decl.name == "main" || decl.name == "aura_user_main")
+            .expect("main declaration should exist");
+        assert!(matches!(module.types.get(main_decl.ty), Some(Ty::Func { .. })));
     }
 
     #[test]

--- a/crates/aura-typecheck/src/types.rs
+++ b/crates/aura-typecheck/src/types.rs
@@ -26,8 +26,6 @@ pub enum Ty {
     Void,
     Never,
     Any,
-    Ptr(TyId),
-    Slice(TyId),
     Nominal(String),
     List(TyId),
     Dict { key: TyId, value: TyId },

--- a/crates/aura-typecheck/src/unify.rs
+++ b/crates/aura-typecheck/src/unify.rs
@@ -82,14 +82,6 @@ impl Unifier {
                 let item = self.unify(interner, a, b, _context)?;
                 Ok(interner.intern(Ty::List(item)))
             }
-            (Some(Ty::Ptr(a)), Some(Ty::Ptr(b))) => {
-                let item = self.unify(interner, a, b, _context)?;
-                Ok(interner.intern(Ty::Ptr(item)))
-            }
-            (Some(Ty::Slice(a)), Some(Ty::Slice(b))) => {
-                let item = self.unify(interner, a, b, _context)?;
-                Ok(interner.intern(Ty::Slice(item)))
-            }
             (Some(Ty::Dict { key: ka, value: va }), Some(Ty::Dict { key: kb, value: vb })) => {
                 if self.occurs(interner, lhs, kb) || self.occurs(interner, rhs, ka) {
                     return Err(Box::new(
@@ -281,8 +273,6 @@ impl Unifier {
         }
         match interner.get(within) {
             Some(Ty::List(item)) => self.occurs(interner, var, *item),
-            Some(Ty::Ptr(item)) => self.occurs(interner, var, *item),
-            Some(Ty::Slice(item)) => self.occurs(interner, var, *item),
             Some(Ty::Dict { key, value }) => {
                 self.occurs(interner, var, *key) || self.occurs(interner, var, *value)
             }

--- a/docs/Generated/Commands Inventory.md
+++ b/docs/Generated/Commands Inventory.md
@@ -2,7 +2,7 @@
 title: Commands Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-21T08:52:12.3907534Z
+generated_at: 2026-04-21T10:03:49.3802758Z
 ---
 
 # Commands Inventory

--- a/docs/Generated/Directory Inventory.md
+++ b/docs/Generated/Directory Inventory.md
@@ -2,7 +2,7 @@
 title: Directory Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-21T08:52:12.3907534Z
+generated_at: 2026-04-21T10:03:49.3802758Z
 ---
 
 # Directory Inventory

--- a/docs/Generated/Examples Inventory.md
+++ b/docs/Generated/Examples Inventory.md
@@ -2,7 +2,7 @@
 title: Examples Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-21T08:52:12.3907534Z
+generated_at: 2026-04-21T10:03:49.3802758Z
 ---
 
 # Examples Inventory

--- a/docs/Generated/Test Inventory.md
+++ b/docs/Generated/Test Inventory.md
@@ -2,7 +2,7 @@
 title: Test Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-21T08:52:12.3907534Z
+generated_at: 2026-04-21T10:03:49.3802758Z
 ---
 
 # Test Inventory

--- a/docs/Generated/Workspace Inventory.md
+++ b/docs/Generated/Workspace Inventory.md
@@ -2,7 +2,7 @@
 title: Workspace Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-21T08:52:12.3907534Z
+generated_at: 2026-04-21T10:03:49.3802758Z
 ---
 
 # Workspace Inventory

--- a/docs/Subsystems/Codegen.md
+++ b/docs/Subsystems/Codegen.md
@@ -15,7 +15,7 @@ related_contracts:
   - "Contracts/Typecheck IR"
 related_notes:
   - "Architecture/Build And Dev Workflow"
-last_reviewed: 2026-04-18
+last_reviewed: 2026-04-21
 ---
 
 # Codegen
@@ -30,7 +30,20 @@ Turn checked Aura modules into backend artifacts, currently centered on the LLVM
 - `emit_object_file`
 - project discovery under `project/`
 
+## Runtime Lowering Notes
+
+LLVM lowering currently treats runtime-backed nominal values such as `Bytes` as pointer-shaped values at the ABI boundary.
+
+For the first byte-buffer path, checked member calls are lowered to runtime symbols:
+
+- `Bytes.new(size)` -> `bytes_new(size)`
+- `bytes.get(index)` -> `bytes_get(bytes, index)`
+- `bytes.set(index, value)` -> `bytes_set(bytes, index, value)`
+- `string.into()` -> `string_into(string_ptr)`
+- `syscall_write(fd, bytes)` -> direct external runtime call
+
+String literals still lower to global NUL-terminated byte storage on the LLVM side. `String.into()` is what materializes owned mutable `Bytes` by copying from that literal/runtime string storage in the runtime host.
+
 ## Testing
 
 LLVM-specific validation runs through `cargo xtask llvm ...`.
-

--- a/docs/Subsystems/Runtime Host.md
+++ b/docs/Subsystems/Runtime Host.md
@@ -18,11 +18,39 @@ last_reviewed: 2026-04-21
 
 ## Purpose
 
-Provide the native runtime boundary required by generated code. The current exported surface is intentionally minimal.
+Provide the native runtime boundary required by generated code. The current exported surface includes process exit plus the first owned byte-buffer ABI used by Aura native code.
 
 ## Current Export
 
 - `syscall_exit`
+- `syscall_write`
+- `bytes_new`
+- `bytes_get`
+- `bytes_set`
+- `string_into`
+
+## `Bytes` ABI
+
+Generated code treats `Bytes` as an opaque pointer-like runtime value. The host owns the concrete representation and currently stores:
+
+- `len: usize`
+- contiguous owned `Vec<u8>` storage
+
+The exported helpers use this object model:
+
+- `bytes_new(size)` allocates zeroed storage and returns an owned `Bytes`
+- `bytes_get(bytes, index)` reads one byte
+- `bytes_set(bytes, index, value)` writes one byte
+- `string_into(string)` copies a NUL-terminated Aura string literal/runtime string into fresh owned `Bytes`
+
+Bounds checks are intentionally absent right now; out-of-bounds `get`/`set` is UB until panic handling exists.
+
+## Native Write Path
+
+- `syscall_write(fd, bytes)` accepts Aura's public ABI shape: `Int32` file descriptor plus `Bytes`
+- the host currently maps `fd = 1` to stdout and `fd = 2` to stderr
+- successful writes return the buffer length as `ISize`
+- unsupported descriptors or host I/O failures return `-1`
 
 ## Native Linking Notes
 

--- a/e2e/hello_world/build.aura
+++ b/e2e/hello_world/build.aura
@@ -1,0 +1,6 @@
+def project = (
+    name = "hello_world",
+    version = "0.1.0",
+    type = .binary,
+    dependencies = [],
+);

--- a/e2e/hello_world/src/main.aura
+++ b/e2e/hello_world/src/main.aura
@@ -1,0 +1,4 @@
+def main() -> Void {
+    syscall_write(1, "Hello, world!".into());
+    syscall_exit(0);
+}


### PR DESCRIPTION
## Summary
- add the owned opaque `Bytes` builtin surface plus `String.into()` and `syscall_write(fd: Int32, bytes: Bytes) -> ISize`
- lower builtin byte methods to runtime-host exports and wire LLVM declarations/object emission for the new ABI
- add a native `e2e/hello_world` fixture and update the runtime/codegen docs plus generated vault inventory

## Why
- replace the old public raw pointer/slice runtime boundary with an owned byte buffer API
- expose the first direct Aura write syscall path for stdout/stderr
- validate the end-to-end native flow with a minimal hello-world program

## Validation
- `cargo test -p aura-typecheck`
- `cargo test -p aura-runtime-host`
- `cargo xtask llvm cargo -- test -p aura-codegen --features llvm-backend`
- `cargo xtask dev check`
- `cargo xtask docs sync`
- `cargo xtask docs check`
- `cargo xtask llvm run -- -p aura-cli -- build e2e/hello_world/src/main.aura --out e2e/hello_world/target/hello_world.exe`
- ran `e2e/hello_world/target/hello_world.exe` and verified stdout was exactly `Hello, world!`