### PR TITLE
feat: add first-class interface type representation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -366,7 +366,7 @@ def any_print(msg: interface(to_string: Func[(), String])) -> Void { ... }
 def ToStr = interface(to_string: Func[(), String])
 ```
 
-The empty interface `interface()` is equivalent to the builtin `Any` type and accepts any value. On the other hand, the `Never` type would be equivalent to an interface with all the imaginable methods, making it impossible to satisfy, yet castable to any other type.
+The compiler models `interface(...)` as a first-class type node through frontend AST and typecheck IR (not as a nominal fallback), preserving each declared member signature. The empty interface `interface()` is equivalent to the builtin `Any` type and accepts any value. On the other hand, the `Never` type would be equivalent to an interface with all the imaginable methods, making it impossible to satisfy, yet castable to any other type.
 
 Union types automatically implement the *intersection* of their member types' interfaces:
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -366,7 +366,7 @@ def any_print(msg: interface(to_string: Func[(), String])) -> Void { ... }
 def ToStr = interface(to_string: Func[(), String])
 ```
 
-The compiler models `interface(...)` as a first-class type node through frontend AST and typecheck IR (not as a nominal fallback), preserving each declared member signature. The empty interface `interface()` is equivalent to the builtin `Any` type and accepts any value. On the other hand, the `Never` type would be equivalent to an interface with all the imaginable methods, making it impossible to satisfy, yet castable to any other type.
+The compiler models `interface(...)` as a first-class type node through frontend AST and typecheck IR (not as a nominal fallback), preserving each declared member signature. Interface constraints are checked structurally against the receiver method set, including named aliases and anonymous `interface(...)` constraints. The empty interface `interface()` is equivalent to the builtin `Any` type and accepts any value. On the other hand, the `Never` type would be equivalent to an interface with all the imaginable methods, making it impossible to satisfy, yet castable to any other type.
 
 Union types automatically implement the *intersection* of their member types' interfaces:
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -368,6 +368,8 @@ def ToStr = interface(to_string: Func[(), String])
 
 The compiler models `interface(...)` as a first-class type node through frontend AST and typecheck IR (not as a nominal fallback), preserving each declared member signature. Interface constraints are checked structurally against the receiver method set, including named aliases and anonymous `interface(...)` constraints. The empty interface `interface()` is equivalent to the builtin `Any` type and accepts any value. On the other hand, the `Never` type would be equivalent to an interface with all the imaginable methods, making it impossible to satisfy, yet castable to any other type.
 
+For runtime behavior, interface-typed values are lowered as interface objects (data pointer + witness/vtable pointer). Calls on interface-typed receivers lower through dynamic dispatch slots, while calls on concrete receiver types keep the direct static-call path.
+
 Union types automatically implement the *intersection* of their member types' interfaces:
 
 ```aura

--- a/crates/aura-codegen/src/llvm/expr.rs
+++ b/crates/aura-codegen/src/llvm/expr.rs
@@ -15,6 +15,7 @@ use super::error::CodegenError;
 use inkwell::{
     AddressSpace,
     module::Linkage,
+    types::BasicType,
     types::BasicTypeEnum,
     values::{
         BasicMetadataValueEnum, BasicValue, BasicValueEnum, FunctionValue, IntValue, PointerValue,
@@ -25,8 +26,8 @@ use inkwell::{
 use super::context::{CodegenContext, LoopTarget};
 #[cfg(feature = "llvm-backend")]
 use super::types::{
-    AuraFunctionType, AuraValueType, aggregate_storage_type, lower_basic_type, type_layout,
-    type_layout_id, type_trace_kind,
+    AuraFunctionType, AuraValueType, aggregate_storage_type, classify_type, lower_basic_type,
+    type_layout, type_layout_id, type_trace_kind,
 };
 
 pub fn classify_expr_kind(expr: &CheckedExpr) -> &'static str {
@@ -38,6 +39,8 @@ pub fn classify_expr_kind(expr: &CheckedExpr) -> &'static str {
         CheckedExpr::String(_) => "string",
         CheckedExpr::EnumCtor { .. } => "enum_ctor",
         CheckedExpr::Call { .. } => "call",
+        CheckedExpr::MakeInterfaceObj { .. } => "make_interface_obj",
+        CheckedExpr::InterfaceCall { .. } => "interface_call",
         CheckedExpr::MemoryOp { .. } => "memory_op",
         CheckedExpr::BinaryOp { .. } => "binary_op",
         CheckedExpr::DotIdent { .. } => "dot_ident",
@@ -286,6 +289,19 @@ pub fn lower_expr<'ctx, 'm>(
         CheckedExpr::Continue { target } => lower_continue_expr(cg, target),
         CheckedExpr::Label { expr, .. } => lower_expr(cg, expr),
         CheckedExpr::Call { callee, args } => lower_call(cg, callee, args),
+        CheckedExpr::MakeInterfaceObj {
+            expr,
+            interface_ty,
+            concrete_ty,
+            method_links,
+        } => lower_make_interface_obj(cg, expr, *interface_ty, *concrete_ty, method_links),
+        CheckedExpr::InterfaceCall {
+            receiver,
+            interface_ty,
+            method_index,
+            args,
+            ..
+        } => lower_interface_call(cg, receiver, *interface_ty, *method_index, args),
         CheckedExpr::MemoryOp {
             op,
             item_ty,
@@ -297,6 +313,300 @@ pub fn lower_expr<'ctx, 'm>(
             expr,
         ))),
     }
+}
+
+#[cfg(feature = "llvm-backend")]
+fn interface_object_type<'ctx>(
+    cg: &CodegenContext<'ctx, '_>,
+) -> inkwell::types::StructType<'ctx> {
+    let ptr = cg.context.ptr_type(AddressSpace::default());
+    cg.context.struct_type(&[ptr.into(), ptr.into()], false)
+}
+
+#[cfg(feature = "llvm-backend")]
+fn lower_make_interface_obj<'ctx, 'm>(
+    cg: &CodegenContext<'ctx, 'm>,
+    expr: &CheckedExpr,
+    interface_ty: aura_typecheck::TyId,
+    concrete_ty: aura_typecheck::TyId,
+    method_links: &[String],
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let lowered = lower_expr(cg, expr)?;
+    let object_ty = interface_object_type(cg);
+    let object_slot = cg
+        .builder
+        .build_malloc(object_ty, "iface_obj")
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    let data_ptr = cg
+        .builder
+        .build_malloc(lowered.get_type(), "iface_data")
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    cg.builder
+        .build_store(data_ptr, lowered)
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+
+    let ptr_ty = cg.context.ptr_type(AddressSpace::default());
+    let table_ty = ptr_ty.array_type(method_links.len() as u32);
+    let table_slot = cg
+        .builder
+        .build_malloc(table_ty, "iface_vtable")
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    for (index, link_name) in method_links.iter().enumerate() {
+        if let Some(function) = cg.module.get_function(link_name) {
+            let thunk =
+                ensure_interface_thunk(cg, interface_ty, concrete_ty, index, link_name, function)?;
+            let slot_ptr = unsafe {
+                cg.builder
+                    .build_in_bounds_gep(
+                        table_ty,
+                        table_slot,
+                        &[
+                            cg.context.i64_type().const_zero(),
+                            cg.context.i64_type().const_int(index as u64, false),
+                        ],
+                        &format!("iface_slot_{index}"),
+                    )
+                    .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?
+            };
+            let fn_ptr = thunk.as_global_value().as_pointer_value().as_basic_value_enum();
+            cg.builder
+                .build_store(slot_ptr, fn_ptr)
+                .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+        }
+    }
+
+    let data_gep = cg
+        .builder
+        .build_struct_gep(object_ty, object_slot, 0, "iface_data_gep")
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    cg.builder
+        .build_store(data_gep, data_ptr.as_basic_value_enum())
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    let vtable_gep = cg
+        .builder
+        .build_struct_gep(object_ty, object_slot, 1, "iface_vtable_gep")
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    cg.builder
+        .build_store(vtable_gep, table_slot.as_basic_value_enum())
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    Ok(object_slot.as_basic_value_enum())
+}
+
+#[cfg(feature = "llvm-backend")]
+fn lower_interface_call<'ctx, 'm>(
+    cg: &CodegenContext<'ctx, 'm>,
+    receiver: &CheckedExpr,
+    interface_ty: aura_typecheck::TyId,
+    method_index: usize,
+    args: &[CheckedExpr],
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let receiver_value = lower_expr(cg, receiver)?;
+    let receiver_ptr = receiver_value.into_pointer_value();
+    let object_ty = interface_object_type(cg);
+    let data_gep = cg
+        .builder
+        .build_struct_gep(object_ty, receiver_ptr, 0, "iface_call_data_gep")
+        .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?;
+    let data_ptr = cg
+        .builder
+        .build_load(
+            cg.context.ptr_type(AddressSpace::default()),
+            data_gep,
+            "iface_call_data",
+        )
+        .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?;
+    let vtable_gep = cg
+        .builder
+        .build_struct_gep(object_ty, receiver_ptr, 1, "iface_call_vtable_gep")
+        .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?;
+    let vtable_ptr = cg
+        .builder
+        .build_load(
+            cg.context.ptr_type(AddressSpace::default()),
+            vtable_gep,
+            "iface_call_vtable",
+        )
+        .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?
+        .into_pointer_value();
+    let ptr_ty = cg.context.ptr_type(AddressSpace::default());
+    let vtable_as_ptr_ptr = cg
+        .builder
+        .build_bit_cast(
+            vtable_ptr,
+            ptr_ty.ptr_type(AddressSpace::default()),
+            "iface_call_vtable_cast",
+        )
+        .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?
+        .into_pointer_value();
+    let slot_ptr = unsafe {
+        cg.builder
+            .build_in_bounds_gep(
+                ptr_ty,
+                vtable_as_ptr_ptr,
+                &[cg.context.i64_type().const_int(method_index as u64, false)],
+                "iface_call_slot",
+            )
+            .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?
+    };
+    let fn_ptr = cg
+        .builder
+        .build_load(ptr_ty, slot_ptr, "iface_call_fnptr")
+        .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?;
+    let fn_ty = interface_thunk_type(cg, interface_ty, method_index)?;
+    let callable = cg
+        .builder
+        .build_bit_cast(
+            fn_ptr.into_pointer_value(),
+            fn_ty.ptr_type(AddressSpace::default()),
+            "iface_call_callable",
+        )
+        .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?
+        .into_pointer_value();
+    let mut lowered_args = Vec::with_capacity(args.len() + 1);
+    lowered_args.push(BasicMetadataValueEnum::from(data_ptr));
+    for arg in args {
+        lowered_args.push(BasicMetadataValueEnum::from(lower_expr(cg, arg)?));
+    }
+    let call = cg
+        .builder
+        .build_indirect_call(fn_ty, callable, &lowered_args, "iface_call")
+        .map_err(|_| CodegenError::UnsupportedExpression("interface_call"))?;
+    if let Some(value) = call.try_as_basic_value().left() {
+        Ok(value)
+    } else {
+        Ok(cg
+            .context
+            .ptr_type(AddressSpace::default())
+            .const_null()
+            .as_basic_value_enum())
+    }
+}
+
+#[cfg(feature = "llvm-backend")]
+fn interface_method_signature(
+    cg: &CodegenContext<'_, '_>,
+    interface_ty: aura_typecheck::TyId,
+    method_index: usize,
+) -> Result<(Vec<aura_typecheck::types::FuncParam>, aura_typecheck::TyId), CodegenError> {
+    let Some(Ty::Interface(members)) = cg.checked.types.get(interface_ty) else {
+        return Err(CodegenError::UnsupportedExpression("interface_call"));
+    };
+    let (_, method_ty) = members
+        .get(method_index)
+        .ok_or(CodegenError::UnsupportedExpression("interface_call"))?;
+    let Some(Ty::Func { params, ret }) = cg.checked.types.get(*method_ty).cloned() else {
+        return Err(CodegenError::UnsupportedExpression("interface_call"));
+    };
+    Ok((params, ret))
+}
+
+#[cfg(feature = "llvm-backend")]
+fn interface_thunk_type<'ctx>(
+    cg: &CodegenContext<'ctx, '_>,
+    interface_ty: aura_typecheck::TyId,
+    method_index: usize,
+) -> Result<inkwell::types::FunctionType<'ctx>, CodegenError> {
+    let (params, ret) = interface_method_signature(cg, interface_ty, method_index)?;
+    let mut llvm_params = Vec::with_capacity(params.len() + 1);
+    llvm_params.push(
+        cg.context
+            .ptr_type(AddressSpace::default())
+            .as_basic_type_enum()
+            .into(),
+    );
+    for param in params {
+        llvm_params.push(lower_basic_type(cg.context, &cg.checked.types, param.ty)?.into());
+    }
+    let ret_kind = classify_type(&cg.checked.types, ret)?;
+    Ok(match ret_kind {
+        AuraValueType::Void => cg.context.void_type().fn_type(&llvm_params, false),
+        _ => lower_basic_type(cg.context, &cg.checked.types, ret)?.fn_type(&llvm_params, false),
+    })
+}
+
+#[cfg(feature = "llvm-backend")]
+fn ensure_interface_thunk<'ctx, 'm>(
+    cg: &CodegenContext<'ctx, 'm>,
+    interface_ty: aura_typecheck::TyId,
+    concrete_ty: aura_typecheck::TyId,
+    method_index: usize,
+    method_link: &str,
+    method_fn: FunctionValue<'ctx>,
+) -> Result<FunctionValue<'ctx>, CodegenError> {
+    let thunk_name = format!("__aura_iface_thunk_{}_{}_{}", concrete_ty.0, method_index, method_link);
+    if let Some(existing) = cg.module.get_function(&thunk_name) {
+        return Ok(existing);
+    }
+    let thunk_ty = interface_thunk_type(cg, interface_ty, method_index)?;
+    let thunk = cg.module.add_function(&thunk_name, thunk_ty, None);
+    let entry = cg.context.append_basic_block(thunk, "entry");
+    cg.builder.position_at_end(entry);
+
+    let data_param = thunk
+        .get_nth_param(0)
+        .ok_or(CodegenError::UnsupportedExpression("make_interface_obj"))?
+        .into_pointer_value();
+    let concrete_basic = lower_basic_type(cg.context, &cg.checked.types, concrete_ty)?;
+    let concrete_ptr = cg
+        .builder
+        .build_bit_cast(
+            data_param,
+            concrete_basic.ptr_type(AddressSpace::default()),
+            "iface_thunk_concrete_ptr",
+        )
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?
+        .into_pointer_value();
+    let concrete_value = cg
+        .builder
+        .build_load(concrete_basic, concrete_ptr, "iface_thunk_concrete")
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+
+    let mut call_args = Vec::new();
+    call_args.push(BasicMetadataValueEnum::from(concrete_value));
+    for idx in 1..thunk.count_params() {
+        if let Some(param) = thunk.get_nth_param(idx) {
+            call_args.push(BasicMetadataValueEnum::from(param));
+        }
+    }
+    let call = cg
+        .builder
+        .build_call(method_fn, &call_args, "iface_thunk_call")
+        .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    if method_fn.get_type().get_return_type().is_some() {
+        let mut ret = call
+            .try_as_basic_value()
+            .left()
+            .ok_or(CodegenError::UnsupportedExpression("make_interface_obj"))?;
+        if let Some(expected_ret) = thunk.get_type().get_return_type() {
+            if let (BasicValueEnum::IntValue(ret_int), BasicTypeEnum::IntType(expected_int)) =
+                (ret, expected_ret)
+            {
+                let from_w = ret_int.get_type().get_bit_width();
+                let to_w = expected_int.get_bit_width();
+                if from_w != to_w {
+                    ret = if from_w > to_w {
+                        cg.builder
+                            .build_int_truncate(ret_int, expected_int, "iface_ret_trunc")
+                            .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?
+                            .as_basic_value_enum()
+                    } else {
+                        cg.builder
+                            .build_int_z_extend(ret_int, expected_int, "iface_ret_zext")
+                            .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?
+                            .as_basic_value_enum()
+                    };
+                }
+            }
+        }
+        cg.builder
+            .build_return(Some(&ret))
+            .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    } else {
+        cg.builder
+            .build_return(None)
+            .map_err(|_| CodegenError::UnsupportedExpression("make_interface_obj"))?;
+    }
+    Ok(thunk)
 }
 
 #[cfg(feature = "llvm-backend")]

--- a/crates/aura-codegen/src/llvm/module.rs
+++ b/crates/aura-codegen/src/llvm/module.rs
@@ -567,4 +567,30 @@ mod tests {
         assert!(out.exists());
         let _ = std::fs::remove_file(out);
     }
+
+    #[cfg(feature = "llvm-backend")]
+    #[test]
+    fn llvm_ir_lowers_interface_dispatch_through_vtable_indirection() {
+        let src = r#"
+            def ToDouble = interface(double: Func[(), ISize]);
+            def Int.double() -> ISize { 2 }
+            def call(x: ToDouble) -> ISize { x.double() }
+            def make_value() -> ToDouble { 1 }
+            def main() -> Void {
+                let value = make_value();
+                call(value);
+                ()
+            }
+        "#;
+        let program = Parser::parse_source(src).expect("parse");
+        let checked = check_module(&program);
+        let module = checked.module.expect("checked module");
+
+        let ir = super::emit_module_stub("iface_dispatch", &module).expect("emit ir");
+        assert!(ir.contains("__aura_iface_thunk_"));
+        assert!(
+            ir.contains("call i32 %iface_call") || ir.contains("call i64 %iface_call"),
+            "expected indirect iface call in IR:\n{ir}"
+        );
+    }
 }

--- a/crates/aura-codegen/src/llvm/types.rs
+++ b/crates/aura-codegen/src/llvm/types.rs
@@ -55,6 +55,7 @@ pub fn classify_type(types: &TyInterner, ty_id: TyId) -> Result<AuraValueType, C
         | Ty::Struct(_)
         | Ty::Union(_)
         | Ty::Interface(_)
+        | Ty::InterfaceObject(_)
         | Ty::GenericParam(_)
         | Ty::InferVar(_) => Ok(AuraValueType::Pointer),
     }
@@ -363,7 +364,9 @@ mod llvm_lowering {
             | Ty::Union(_)
             | Ty::GenericParam(_)
             | Ty::InferVar(_)
-            | Ty::Any => true,
+            | Ty::Any
+            | Ty::Interface(_)
+            | Ty::InterfaceObject(_) => true,
         })
     }
 

--- a/crates/aura-codegen/src/llvm/types.rs
+++ b/crates/aura-codegen/src/llvm/types.rs
@@ -54,6 +54,7 @@ pub fn classify_type(types: &TyInterner, ty_id: TyId) -> Result<AuraValueType, C
         | Ty::Tuple(_)
         | Ty::Struct(_)
         | Ty::Union(_)
+        | Ty::Interface(_)
         | Ty::GenericParam(_)
         | Ty::InferVar(_) => Ok(AuraValueType::Pointer),
     }

--- a/crates/aura-codegen/src/project/compile.rs
+++ b/crates/aura-codegen/src/project/compile.rs
@@ -1005,6 +1005,12 @@ fn ty_to_type_ref(types: &TyInterner, ty_id: aura_typecheck::TyId) -> TypeRef {
         Some(Ty::Union(items)) => {
             TypeRef::Union(items.iter().map(|ty| ty_to_type_ref(types, *ty)).collect())
         }
+        Some(Ty::Interface(members)) => TypeRef::Interface(
+            members
+                .iter()
+                .map(|(name, ty)| (name.clone(), ty_to_type_ref(types, *ty)))
+                .collect(),
+        ),
         Some(Ty::Enum(variants)) => TypeRef::Enum(
             variants
                 .iter()
@@ -1121,6 +1127,13 @@ fn ty_ref_to_ty_id(types: &mut TyInterner, ty: &TypeRef) -> aura_typecheck::TyId
                 .map(|item| ty_ref_to_ty_id(types, item))
                 .collect::<Vec<_>>();
             types.intern(Ty::Union(items))
+        }
+        TypeRef::Interface(members) => {
+            let members = members
+                .iter()
+                .map(|(name, ty)| (name.clone(), ty_ref_to_ty_id(types, ty)))
+                .collect::<Vec<_>>();
+            types.intern(Ty::Interface(members))
         }
         TypeRef::Enum(variants) => {
             let variants = variants

--- a/crates/aura-codegen/src/project/compile.rs
+++ b/crates/aura-codegen/src/project/compile.rs
@@ -1005,7 +1005,7 @@ fn ty_to_type_ref(types: &TyInterner, ty_id: aura_typecheck::TyId) -> TypeRef {
         Some(Ty::Union(items)) => {
             TypeRef::Union(items.iter().map(|ty| ty_to_type_ref(types, *ty)).collect())
         }
-        Some(Ty::Interface(members)) => TypeRef::Interface(
+        Some(Ty::Interface(members)) | Some(Ty::InterfaceObject(members)) => TypeRef::Interface(
             members
                 .iter()
                 .map(|(name, ty)| (name.clone(), ty_to_type_ref(types, *ty)))
@@ -1229,6 +1229,22 @@ fn collect_expr_external_link_names(
         }
         CheckedExpr::Call { callee, args } => {
             collect_expr_external_link_names(callee, extern_links, out);
+            for arg in args {
+                collect_expr_external_link_names(arg, extern_links, out);
+            }
+        }
+        CheckedExpr::MakeInterfaceObj {
+            expr, method_links, ..
+        } => {
+            collect_expr_external_link_names(expr, extern_links, out);
+            for link in method_links {
+                if extern_links.contains(link) {
+                    out.insert(link.clone());
+                }
+            }
+        }
+        CheckedExpr::InterfaceCall { receiver, args, .. } => {
+            collect_expr_external_link_names(receiver, extern_links, out);
             for arg in args {
                 collect_expr_external_link_names(arg, extern_links, out);
             }

--- a/crates/aura-diagnostics/src/issue.rs
+++ b/crates/aura-diagnostics/src/issue.rs
@@ -48,6 +48,12 @@ pub enum Issue {
     InterfaceBoundUnsatisfied {
         detail: String,
     },
+    InterfaceMethodMissing {
+        detail: String,
+    },
+    InterfaceMethodMismatch {
+        detail: String,
+    },
     MacroUntyped,
     MainSignature,
     OpNonNumeric,
@@ -112,6 +118,8 @@ impl Issue {
             Self::IfArity => "E_IF_ARITY",
             Self::IfForm => "E_IF_FORM",
             Self::InterfaceBoundUnsatisfied { .. } => "E_INTERFACE_BOUND_UNSAT",
+            Self::InterfaceMethodMissing { .. } => "E_INTERFACE_METHOD_MISSING",
+            Self::InterfaceMethodMismatch { .. } => "E_INTERFACE_METHOD_MISMATCH",
             Self::MacroUntyped => "E_MACRO_UNTYPED",
             Self::MainSignature => "E_MAIN_SIGNATURE",
             Self::OpNonNumeric => "E_OP_NON_NUMERIC",
@@ -186,6 +194,8 @@ impl Issue {
             Self::IfArity => "if expects one runtime argument: condition".to_string(),
             Self::IfForm => "invalid if form".to_string(),
             Self::InterfaceBoundUnsatisfied { detail } => detail.clone(),
+            Self::InterfaceMethodMissing { detail } => detail.clone(),
+            Self::InterfaceMethodMismatch { detail } => detail.clone(),
             Self::MacroUntyped => "macro value used where typed value is required".to_string(),
             Self::MainSignature => "invalid main signature".to_string(),
             Self::OpNonNumeric => "numeric operator requires numeric operands".to_string(),

--- a/crates/aura-diagnostics/src/type_ref.rs
+++ b/crates/aura-diagnostics/src/type_ref.rs
@@ -58,6 +58,7 @@ pub enum TypeRef {
     Tuple(Vec<TypeRef>),
     Struct(Vec<(String, TypeRef)>),
     Union(Vec<TypeRef>),
+    Interface(Vec<(String, TypeRef)>),
     Enum(Vec<(String, Option<TypeRef>)>),
     Unknown,
     RawAlloc(Box<TypeRef>),
@@ -142,6 +143,14 @@ impl fmt::Display for TypeRef {
                     .collect::<Vec<_>>()
                     .join(" | ");
                 write!(f, "union({joined})")
+            }
+            Self::Interface(members) => {
+                let joined = members
+                    .iter()
+                    .map(|(name, ty)| format!("{name}: {ty}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "interface({joined})")
             }
             Self::Enum(variants) => {
                 let joined = variants

--- a/crates/aura-frontend/src/ast.rs
+++ b/crates/aura-frontend/src/ast.rs
@@ -95,6 +95,7 @@ pub struct Param {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeExpr {
     Named { name: String, args: Vec<StaticArg> },
+    Interface(Vec<(String, TypeExpr)>),
     Tuple(Vec<TypeExpr>),
     Struct(Vec<(String, TypeExpr)>),
     Static(Box<TypeExpr>),

--- a/crates/aura-frontend/src/fmt.rs
+++ b/crates/aura-frontend/src/fmt.rs
@@ -654,6 +654,18 @@ impl<'a> Formatter<'a> {
                 self.out.push_str(name);
                 self.write_static_args(args);
             }
+            TypeExpr::Interface(fields) => {
+                self.out.push_str("interface(");
+                for (i, (name, ty)) in fields.iter().enumerate() {
+                    if i > 0 {
+                        self.out.push_str(", ");
+                    }
+                    self.out.push_str(name);
+                    self.out.push_str(": ");
+                    self.write_type_expr(ty);
+                }
+                self.out.push(')');
+            }
             TypeExpr::Tuple(items) => {
                 self.out.push('(');
                 for (i, item) in items.iter().enumerate() {

--- a/crates/aura-frontend/src/parser.rs
+++ b/crates/aura-frontend/src/parser.rs
@@ -716,6 +716,11 @@ where
             return Ok(TypeExpr::Static(Box::new(inner)));
         }
 
+        if self.peek_ident_is("interface") {
+            self.bump();
+            return self.parse_interface_type_expr();
+        }
+
         if self.peek_is(&TokenKind::Underscore) {
             self.bump();
             return Ok(TypeExpr::InferHole);
@@ -731,6 +736,47 @@ where
         };
 
         Ok(TypeExpr::Named { name, args })
+    }
+
+    fn parse_interface_type_expr(&mut self) -> Result<TypeExpr, ParseError> {
+        self.expect_simple(
+            &TokenKind::LParen,
+            "expected '(' after interface",
+            vec!["("],
+        )?;
+        if self.peek_is(&TokenKind::RParen) {
+            self.bump();
+            return Ok(TypeExpr::Interface(Vec::new()));
+        }
+
+        let mut fields = Vec::new();
+        loop {
+            let field = self.expect_ident("expected interface method name")?;
+            self.expect_simple(
+                &TokenKind::Colon,
+                "expected ':' after interface method name",
+                vec![":"],
+            )?;
+            let ty = self.parse_type_expr()?;
+            fields.push((field, ty));
+
+            if self.peek_is(&TokenKind::Comma) {
+                self.bump();
+                if self.peek_is(&TokenKind::RParen) {
+                    self.bump();
+                    break;
+                }
+                continue;
+            }
+            self.expect_simple(
+                &TokenKind::RParen,
+                "expected ')' after interface members",
+                vec![")"],
+            )?;
+            break;
+        }
+
+        Ok(TypeExpr::Interface(fields))
     }
 
     fn parse_paren_type_expr(&mut self) -> Result<TypeExpr, ParseError> {
@@ -3270,6 +3316,57 @@ mod tests {
         assert!(
             matches!(u(result), Expr::TypeExpr(TypeExpr::Named { name, .. }) if name == "enum")
         );
+    }
+
+    #[test]
+    fn parse_interface_type_alias_and_annotation() {
+        let src = "def Reader = interface(read: Func[(), String]); def x: interface(read: Func[(), String]) = y";
+        let parsed = Parser::parse_source(src).expect("should parse interface type forms");
+        assert_eq!(parsed.declarations.len(), 2);
+
+        let alias = match &parsed.declarations[0] {
+            Decl::Assign { value, .. } => value,
+            _ => panic!("expected assignment"),
+        };
+        assert!(matches!(
+            u(alias),
+            Expr::TypeExpr(TypeExpr::Interface(fields))
+                if fields.len() == 1 && fields[0].0 == "read"
+        ));
+
+        let annotated = match &parsed.declarations[1] {
+            Decl::Assign { value, .. } => value,
+            _ => panic!("expected assignment"),
+        };
+        assert!(matches!(
+            u(annotated),
+            Expr::Binary {
+                op: crate::ast::BinaryOp::Colon,
+                rhs,
+                ..
+            } if matches!(u(rhs.as_ref()), Expr::TypeExpr(TypeExpr::Interface(fields)) if fields.len() == 1)
+        ));
+    }
+
+    #[test]
+    fn parse_empty_interface_type() {
+        let src = "def AnyLike = interface()";
+        let parsed = Parser::parse_source(src).expect("should parse empty interface type");
+        let value = match &parsed.declarations[0] {
+            Decl::Assign { value, .. } => value,
+            _ => panic!("expected assignment"),
+        };
+        assert!(matches!(
+            u(value),
+            Expr::TypeExpr(TypeExpr::Interface(fields)) if fields.is_empty()
+        ));
+    }
+
+    #[test]
+    fn reject_malformed_interface_member_syntax() {
+        let src = "def Broken = interface(read Func[(), String])";
+        let err = Parser::parse_source(src).expect_err("interface member syntax should require ':'");
+        assert!(err.message.contains("expected"));
     }
 
     #[test]

--- a/crates/aura-typecheck/src/checked_ir.rs
+++ b/crates/aura-typecheck/src/checked_ir.rs
@@ -27,6 +27,7 @@ pub enum CheckedTypeExpr {
         name: String,
         args: Vec<CheckedStaticArg>,
     },
+    Interface(Vec<(String, CheckedTypeExpr)>),
     Static(Box<CheckedTypeExpr>),
     InferHole,
 }

--- a/crates/aura-typecheck/src/checked_ir.rs
+++ b/crates/aura-typecheck/src/checked_ir.rs
@@ -108,6 +108,20 @@ pub enum CheckedExpr {
         callee: Box<CheckedExpr>,
         args: Vec<CheckedExpr>,
     },
+    MakeInterfaceObj {
+        expr: Box<CheckedExpr>,
+        interface_ty: TyId,
+        concrete_ty: TyId,
+        method_links: Vec<String>,
+    },
+    InterfaceCall {
+        receiver: Box<CheckedExpr>,
+        interface_ty: TyId,
+        method: String,
+        method_index: usize,
+        args: Vec<CheckedExpr>,
+        ret_ty: TyId,
+    },
     MemoryOp {
         op: MemoryOpKind,
         item_ty: TyId,

--- a/crates/aura-typecheck/src/checker.rs
+++ b/crates/aura-typecheck/src/checker.rs
@@ -131,7 +131,7 @@ enum TypeConstraint {
     },
     InterfaceBound {
         ty: TyId,
-        interface: String,
+        interface: TypeExpr,
         context: String,
         obligations: Vec<String>,
         span: Option<aura_diagnostics::Span>,
@@ -149,6 +149,20 @@ enum TypeConstraint {
         context: String,
         obligations: Vec<String>,
         span: Option<aura_diagnostics::Span>,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum InterfaceCheckFailure {
+    MissingMethod {
+        interface: String,
+        method: String,
+    },
+    SignatureMismatch {
+        interface: String,
+        method: String,
+        expected: TyId,
+        actual: TyId,
     },
 }
 
@@ -4188,22 +4202,21 @@ impl TypeChecker {
             for c in &param.constraints {
                 match c {
                     GenericConstraint::Interface(interface) => {
-                        let interface_name = match interface {
-                            TypeExpr::Named { name, .. } => name.clone(),
-                            TypeExpr::Interface(_) => "interface".to_string(),
-                            other => format!("{other:?}"),
-                        };
-                        self.pending_constraints
-                            .push(TypeConstraint::InterfaceExists {
-                                interface: interface_name.clone(),
+                        if let TypeExpr::Named {
+                            name: iface_name, ..
+                        } = interface
+                        {
+                            self.pending_constraints.push(TypeConstraint::InterfaceExists {
+                                interface: iface_name.clone(),
                                 context: format!("generic call `{name}` for `{}`", param.name),
                                 obligations: self.obligation_stack.clone(),
                                 span: self.current_expr_span,
                             });
+                        }
                         self.pending_constraints
                             .push(TypeConstraint::InterfaceBound {
                                 ty: mapped,
-                                interface: interface_name,
+                                interface: interface.clone(),
                                 context: format!("generic call `{name}` for `{}`", param.name),
                                 obligations: self.obligation_stack.clone(),
                                 span: self.current_expr_span,
@@ -4441,7 +4454,7 @@ impl TypeChecker {
                     obligations,
                     span,
                 } => {
-                    if !self.interfaces.contains(&interface) {
+                    if !self.interface_name_exists(&interface) {
                         let prev_obligations = self.obligation_stack.clone();
                         let prev_span = self.current_expr_span;
                         self.obligation_stack = obligations;
@@ -4523,18 +4536,71 @@ impl TypeChecker {
                         continue;
                     }
 
-                    if !self.satisfies_interface(&resolved, &interface) {
+                    if let Some(failure) = self.interface_failure_for_type(ty, &interface) {
+                        match failure {
+                            InterfaceCheckFailure::MissingMethod { interface, method } => {
+                                let detail = format!(
+                                    "type `{:?}` is missing interface method `{}` required by `{}` in {}",
+                                    resolved, method, interface, context
+                                );
+                                self.diagnostics.push(
+                                    self.typecheck_error(
+                                        Issue::InterfaceMethodMissing {
+                                            detail: detail.clone(),
+                                        },
+                                        detail,
+                                    )
+                                    .with_hint(
+                                        "define the missing method on the receiver type or choose a different type",
+                                    ),
+                                );
+                            }
+                            InterfaceCheckFailure::SignatureMismatch {
+                                interface,
+                                method,
+                                expected,
+                                actual,
+                            } => {
+                                let expected_ref = self
+                                    .interner
+                                    .get(expected)
+                                    .map(|ty| ty_to_ref(ty, &self.interner))
+                                    .unwrap_or(TypeRef::Unknown);
+                                let actual_ref = self
+                                    .interner
+                                    .get(actual)
+                                    .map(|ty| ty_to_ref(ty, &self.interner))
+                                    .unwrap_or(TypeRef::Unknown);
+                                let detail = format!(
+                                    "type `{:?}` has method `{}` with incompatible signature for `{}` in {}: expected `{}`, got `{}`",
+                                    resolved, method, interface, context, expected_ref, actual_ref
+                                );
+                                self.diagnostics.push(
+                                    self.typecheck_error(
+                                        Issue::InterfaceMethodMismatch {
+                                            detail: detail.clone(),
+                                        },
+                                        detail,
+                                    )
+                                    .with_hint(
+                                        "align the method signature with the interface contract",
+                                    ),
+                                );
+                            }
+                        }
+
+                        let interface_label = self.interface_label(&interface);
                         self.diagnostics.push(
                             self.typecheck_error(
                                 Issue::InterfaceBoundUnsatisfied {
                                     detail: format!(
                                         "type `{:?}` does not satisfy interface bound `{}` in {}",
-                                        resolved, interface, context
+                                        resolved, interface_label, context
                                     ),
                                 },
                                 format!(
                                     "type {:?} does not satisfy interface bound '{}' in {}",
-                                    resolved, interface, context
+                                    resolved, interface_label, context
                                 ),
                             )
                             .with_hint(
@@ -4629,7 +4695,121 @@ impl TypeChecker {
         }
     }
 
-    fn satisfies_interface(&self, ty: &Ty, interface: &str) -> bool {
+    fn interface_name_exists(&mut self, interface: &str) -> bool {
+        if self.interfaces.contains(interface) {
+            return true;
+        }
+        if let Some(alias) = self.aliases.get(interface) {
+            return matches!(self.interner.get(alias), Some(Ty::Interface(_) | Ty::Any));
+        }
+        if let Some((static_params, body)) = self.aliases.get_generic(interface) {
+            if static_params.is_empty() {
+                let ty = self.resolve_type_expr(&body);
+                return matches!(self.interner.get(ty), Some(Ty::Interface(_) | Ty::Any));
+            }
+        }
+        false
+    }
+
+    fn interface_label(&self, interface: &TypeExpr) -> String {
+        match interface {
+            TypeExpr::Named { name, .. } => name.clone(),
+            TypeExpr::Interface(_) => "interface(...)".to_string(),
+            other => format!("{other:?}"),
+        }
+    }
+
+    fn interface_failure_for_type(
+        &mut self,
+        subject_ty: TyId,
+        interface_expr: &TypeExpr,
+    ) -> Option<InterfaceCheckFailure> {
+        let subject_ty = self.unifier.resolve(subject_ty);
+        let Some(subject) = self.interner.get(subject_ty).cloned() else {
+            return None;
+        };
+
+        if let TypeExpr::Named { name, .. } = interface_expr {
+            if self.interface_name_exists(name) {
+                let is_prelude = self.interfaces.contains(name)
+                    && self.aliases.get(name).is_none()
+                    && self.aliases.get_generic(name).is_none();
+                if is_prelude && !self.satisfies_prelude_interface(&subject, name) {
+                    return Some(InterfaceCheckFailure::MissingMethod {
+                        interface: name.clone(),
+                        method: "<prelude-contract>".to_string(),
+                    });
+                }
+            }
+        }
+
+        let interface_ty = self.resolve_type_expr(interface_expr);
+        let interface_ty = self.unifier.resolve(interface_ty);
+        let Some(interface) = self.interner.get(interface_ty).cloned() else {
+            return None;
+        };
+        let Ty::Interface(required_methods) = interface else {
+            if matches!(interface, Ty::Any) {
+                return None;
+            }
+            return Some(InterfaceCheckFailure::MissingMethod {
+                interface: self.interface_label(interface_expr),
+                method: "<not-an-interface>".to_string(),
+            });
+        };
+
+        for (method_name, expected_ty) in required_methods {
+            let Some(method) = self.lookup_method(subject_ty, &method_name) else {
+                return Some(InterfaceCheckFailure::MissingMethod {
+                    interface: self.interface_label(interface_expr),
+                    method: method_name,
+                });
+            };
+            if !self.structurally_equivalent(expected_ty, method.ty) {
+                return Some(InterfaceCheckFailure::SignatureMismatch {
+                    interface: self.interface_label(interface_expr),
+                    method: method_name,
+                    expected: expected_ty,
+                    actual: method.ty,
+                });
+            }
+        }
+        None
+    }
+
+    fn interface_failure_for_interface_ty(
+        &mut self,
+        subject_ty: TyId,
+        interface_ty: TyId,
+    ) -> Option<InterfaceCheckFailure> {
+        let subject_ty = self.unifier.resolve(subject_ty);
+        let interface_ty = self.unifier.resolve(interface_ty);
+        let Some(interface) = self.interner.get(interface_ty).cloned() else {
+            return None;
+        };
+        let Ty::Interface(required_methods) = interface else {
+            return None;
+        };
+        for (method_name, expected_ty) in required_methods {
+            let Some(method) = self.lookup_method(subject_ty, &method_name) else {
+                return Some(InterfaceCheckFailure::MissingMethod {
+                    interface: "interface(...)".to_string(),
+                    method: method_name,
+                });
+            };
+            if !self.structurally_equivalent(expected_ty, method.ty) {
+                return Some(InterfaceCheckFailure::SignatureMismatch {
+                    interface: "interface(...)".to_string(),
+                    method: method_name,
+                    expected: expected_ty,
+                    actual: method.ty,
+                });
+            }
+        }
+        None
+    }
+
+    fn satisfies_prelude_interface(&self, ty: &Ty, interface: &str) -> bool {
         match interface {
             "interface" => matches!(ty, Ty::Any | Ty::Interface(_)),
             "Eq" => matches!(
@@ -4734,6 +4914,16 @@ impl TypeChecker {
 
         if matches!(actual_ty, Ty::Never) {
             return ConversionDecision::Identity;
+        }
+
+        if matches!(expected_ty, Ty::Interface(_)) {
+            if self
+                .interface_failure_for_interface_ty(actual, expected)
+                .is_none()
+            {
+                return ConversionDecision::Identity;
+            }
+            return ConversionDecision::Incompatible;
         }
 
         if matches!(mode, ConversionMode::ImplicitOnly)
@@ -8893,6 +9083,77 @@ mod tests {
             .diagnostics
             .iter()
             .any(|d| !d.obligations.is_empty()));
+    }
+
+    #[test]
+    fn named_interface_alias_bound_succeeds_with_structural_method_set() {
+        let src = r#"
+            def ToDouble = interface(double: Func[(), Int]);
+            def Int.double() -> Int { 2 }
+            def[T: ToDouble] id(x: T) -> T { x }
+            def y = id[Int](1)
+        "#;
+        let parsed = Parser::parse_source(src).expect("parse should succeed");
+        let checked = check_module(&parsed);
+        assert!(
+            checked.module.is_some(),
+            "expected module, diagnostics: {:?}",
+            checked.diagnostics
+        );
+        assert!(
+            checked
+                .diagnostics
+                .iter()
+                .all(|d| d.severity != aura_diagnostics::Severity::Error)
+        );
+    }
+
+    #[test]
+    fn anonymous_interface_assignment_checks_method_presence_structurally() {
+        let src = r#"
+            def Int.double() -> Int { 2 }
+            def x: interface(double: Func[(), Int]) = 1
+        "#;
+        let parsed = Parser::parse_source(src).expect("parse should succeed");
+        let checked = check_module(&parsed);
+        assert!(
+            checked.module.is_some(),
+            "expected module, diagnostics: {:?}",
+            checked.diagnostics
+        );
+    }
+
+    #[test]
+    fn missing_interface_method_emits_specific_diagnostic() {
+        let src = r#"
+            def NeedsDouble = interface(double: Func[(), Int]);
+            def[T: NeedsDouble] id(x: T) -> T { x }
+            def y = id[Int](1)
+        "#;
+        let parsed = Parser::parse_source(src).expect("parse should succeed");
+        let checked = check_module(&parsed);
+        assert!(checked.module.is_none());
+        assert!(checked
+            .diagnostics
+            .iter()
+            .any(|d| d.code_str() == "E_INTERFACE_METHOD_MISSING"));
+    }
+
+    #[test]
+    fn interface_method_signature_mismatch_emits_specific_diagnostic() {
+        let src = r#"
+            def NeedsDouble = interface(double: Func[(), Int]);
+            def Int.double() -> Float { 2.0 }
+            def[T: NeedsDouble] id(x: T) -> T { x }
+            def y = id[Int](1)
+        "#;
+        let parsed = Parser::parse_source(src).expect("parse should succeed");
+        let checked = check_module(&parsed);
+        assert!(checked.module.is_none());
+        assert!(checked
+            .diagnostics
+            .iter()
+            .any(|d| d.code_str() == "E_INTERFACE_METHOD_MISMATCH"));
     }
 
     #[test]

--- a/crates/aura-typecheck/src/checker.rs
+++ b/crates/aura-typecheck/src/checker.rs
@@ -444,6 +444,13 @@ impl TypeChecker {
                     .collect::<Vec<_>>();
                 self.interner.intern(Ty::Union(item_tys))
             }
+            TypeRef::Interface(members) => {
+                let member_tys = members
+                    .iter()
+                    .map(|(name, ty)| (name.clone(), self.type_ref_to_ty(ty)))
+                    .collect::<Vec<_>>();
+                self.interner.intern(Ty::Interface(member_tys))
+            }
             TypeRef::Enum(variants) => {
                 let lowered = variants
                     .iter()
@@ -3282,6 +3289,12 @@ impl TypeChecker {
                 name: name.clone(),
                 args: args.iter().map(|a| self.lower_static_arg(a)).collect(),
             },
+            TypeExpr::Interface(fields) => CheckedTypeExpr::Interface(
+                fields
+                    .iter()
+                    .map(|(name, ty)| (name.clone(), self.lower_type_expr(ty)))
+                    .collect(),
+            ),
             TypeExpr::Tuple(items) if items.is_empty() => CheckedTypeExpr::Named {
                 name: "Void".to_string(),
                 args: Vec::new(),
@@ -3423,6 +3436,9 @@ impl TypeChecker {
             Some(Ty::Struct(fields)) => fields
                 .iter()
                 .any(|(_, field_ty)| self.type_contains_infer_var(*field_ty)),
+            Some(Ty::Interface(members)) => members
+                .iter()
+                .any(|(_, member_ty)| self.type_contains_infer_var(*member_ty)),
             Some(Ty::Enum(variants)) => variants
                 .iter()
                 .any(|(_, payload)| payload.is_some_and(|ty| self.type_contains_infer_var(ty))),
@@ -3454,6 +3470,16 @@ impl TypeChecker {
                     .map(|(name, ty)| (name.clone(), self.resolve_type_expr(ty)))
                     .collect::<Vec<_>>();
                 self.interner.intern(Ty::Struct(lowered))
+            }
+            TypeExpr::Interface(members) => {
+                if members.is_empty() {
+                    return self.interner.intern(Ty::Any);
+                }
+                let lowered = members
+                    .iter()
+                    .map(|(name, ty)| (name.clone(), self.resolve_type_expr(ty)))
+                    .collect::<Vec<_>>();
+                self.interner.intern(Ty::Interface(lowered))
             }
             TypeExpr::Named { name, args } => {
                 if let Some(alias) = self.aliases.get(name) {
@@ -3506,6 +3532,21 @@ impl TypeChecker {
                         return self.unknown_ty();
                     }
                     return self.interner.intern(Ty::Enum(variants));
+                }
+
+                if name == "interface" {
+                    let mut members = Vec::new();
+                    for arg in args {
+                        if let StaticArg::Type(TypeExpr::Struct(items)) = arg {
+                            for (field, ty) in items {
+                                members.push((field.clone(), self.resolve_type_expr(ty)));
+                            }
+                        }
+                    }
+                    if members.is_empty() {
+                        return self.interner.intern(Ty::Any);
+                    }
+                    return self.interner.intern(Ty::Interface(members));
                 }
 
                 if name == "Result" {
@@ -4147,9 +4188,14 @@ impl TypeChecker {
             for c in &param.constraints {
                 match c {
                     GenericConstraint::Interface(interface) => {
+                        let interface_name = match interface {
+                            TypeExpr::Named { name, .. } => name.clone(),
+                            TypeExpr::Interface(_) => "interface".to_string(),
+                            other => format!("{other:?}"),
+                        };
                         self.pending_constraints
                             .push(TypeConstraint::InterfaceExists {
-                                interface: interface.clone(),
+                                interface: interface_name.clone(),
                                 context: format!("generic call `{name}` for `{}`", param.name),
                                 obligations: self.obligation_stack.clone(),
                                 span: self.current_expr_span,
@@ -4157,7 +4203,7 @@ impl TypeChecker {
                         self.pending_constraints
                             .push(TypeConstraint::InterfaceBound {
                                 ty: mapped,
-                                interface: interface.clone(),
+                                interface: interface_name,
                                 context: format!("generic call `{name}` for `{}`", param.name),
                                 obligations: self.obligation_stack.clone(),
                                 span: self.current_expr_span,
@@ -4562,11 +4608,19 @@ impl TypeChecker {
             StaticParamKind::Constraint(TypeExpr::Static(inner)) => {
                 vec![GenericConstraint::Static((**inner).clone())]
             }
-            StaticParamKind::Constraint(TypeExpr::Named { name, args: _ }) => {
-                vec![GenericConstraint::Interface(name.clone())]
+            StaticParamKind::Constraint(TypeExpr::Named { name, args }) => {
+                vec![GenericConstraint::Interface(TypeExpr::Named {
+                    name: name.clone(),
+                    args: args.clone(),
+                })]
+            }
+            StaticParamKind::Constraint(TypeExpr::Interface(members)) => {
+                vec![GenericConstraint::Interface(TypeExpr::Interface(
+                    members.clone(),
+                ))]
             }
             StaticParamKind::Constraint(other) => {
-                vec![GenericConstraint::Interface(format!("{:?}", other))]
+                vec![GenericConstraint::Interface(other.clone())]
             }
         };
         FunctionGenericInfo {
@@ -4577,6 +4631,7 @@ impl TypeChecker {
 
     fn satisfies_interface(&self, ty: &Ty, interface: &str) -> bool {
         match interface {
+            "interface" => matches!(ty, Ty::Any | Ty::Interface(_)),
             "Eq" => matches!(
                 ty,
                 Ty::Bool
@@ -6112,6 +6167,19 @@ fn ty_to_ref(ty: &Ty, interner: &TyInterner) -> TypeRef {
                 })
                 .collect::<Vec<_>>();
             TypeRef::Union(refs)
+        }
+        Ty::Interface(members) => {
+            let refs = members
+                .iter()
+                .map(|(name, id)| {
+                    let ty_ref = interner
+                        .get(*id)
+                        .map(|t| ty_to_ref(t, interner))
+                        .unwrap_or(TypeRef::Unknown);
+                    (name.clone(), ty_ref)
+                })
+                .collect::<Vec<_>>();
+            TypeRef::Interface(refs)
         }
         Ty::Enum(variants) => {
             let refs = variants

--- a/crates/aura-typecheck/src/checker.rs
+++ b/crates/aura-typecheck/src/checker.rs
@@ -176,6 +176,7 @@ enum ConversionMode {
 enum ConversionDecision {
     Identity,
     Coerce,
+    MakeInterfaceObj,
     Cast,
     Incompatible,
 }
@@ -876,6 +877,95 @@ impl TypeChecker {
             }
         }
         None
+    }
+
+    fn interface_method_sig(
+        &self,
+        interface_ty: TyId,
+        field: &str,
+    ) -> Option<(usize, Vec<FuncParam>, TyId)> {
+        let interface_ty = self.unifier.resolve(interface_ty);
+        let Some(Ty::Interface(members) | Ty::InterfaceObject(members)) = self.interner.get(interface_ty)
+        else {
+            return None;
+        };
+        let (method_index, (_, method_ty)) = members
+            .iter()
+            .enumerate()
+            .find(|(_, (name, _))| name == field)?;
+        let resolved_method_ty = self.unifier.resolve(*method_ty);
+        let Some(Ty::Func { params, ret }) = self.interner.get(resolved_method_ty).cloned() else {
+            return None;
+        };
+        Some((method_index, params, ret))
+    }
+
+    fn infer_interface_member_call(
+        &mut self,
+        receiver_ty: TyId,
+        field: &str,
+        args: &[Expr],
+        trailing: &[LabeledClosureArg],
+        expected: Option<TyId>,
+    ) -> Option<TyId> {
+        let Some((_, params, ret)) = self.interface_method_sig(receiver_ty, field) else {
+            return None;
+        };
+        if !trailing.is_empty() {
+            self.diagnostics.push(
+                self.typecheck_error(
+                    Issue::TypeMismatch {
+                        context: TypingContext::Custom("call".to_string()),
+                        expected: TypeRef::Unknown,
+                        actual: TypeRef::Unknown,
+                    },
+                    "interface dispatch does not support trailing closure arguments",
+                )
+                .with_hint("pass all interface call arguments positionally"),
+            );
+            return Some(self.unknown_ty());
+        }
+        if args.len() != params.len() {
+            self.diagnostics.push(
+                self.typecheck_error(
+                    Issue::TypeMismatch {
+                        context: TypingContext::Custom("call".to_string()),
+                        expected: TypeRef::Unknown,
+                        actual: TypeRef::Unknown,
+                    },
+                    format!(
+                        "interface method expects {} argument(s), found {}",
+                        params.len(),
+                        args.len()
+                    ),
+                )
+                .with_hint("match the interface method signature arity"),
+            );
+            return Some(self.unknown_ty());
+        }
+        for (arg, param) in args.iter().zip(params.iter()) {
+            let actual = self.infer_expr_with_expected(arg, param.ty);
+            self.require_assignable(param.ty, actual, "interface method argument");
+        }
+        if let Some(expected) = expected {
+            self.require_assignable(expected, ret, "bidirectional expected type");
+        }
+        Some(ret)
+    }
+
+    fn interface_method_links(&mut self, concrete_ty: TyId, interface_ty: TyId) -> Vec<String> {
+        let interface_ty = self.unifier.resolve(interface_ty);
+        let Some(Ty::Interface(members)) = self.interner.get(interface_ty).cloned() else {
+            return Vec::new();
+        };
+        members
+            .iter()
+            .map(|(method, _)| {
+                self.lookup_method(concrete_ty, method)
+                    .map(|binding| binding.link_name)
+                    .unwrap_or_else(|| method.clone())
+            })
+            .collect()
     }
 
     fn match_receiver_ty(
@@ -2204,6 +2294,11 @@ impl TypeChecker {
                 if let Expr::Member { object, field } = TypeChecker::base_expr(callee.as_ref()) {
                     if let Some(receiver_ty) = self.resolve_type_receiver_expr(object) {
                         let receiver_ty = self.unifier.resolve(receiver_ty);
+                        if let Some(ret) =
+                            self.infer_interface_member_call(receiver_ty, field, args, trailing, None)
+                        {
+                            return ret;
+                        }
                         if let Some(method) = self.lookup_method(receiver_ty, field) {
                             self.record_method_call(expr, method.link_name.clone());
                             self.record_method_call(callee.as_ref(), method.link_name.clone());
@@ -2219,6 +2314,11 @@ impl TypeChecker {
                     }
                     let receiver_ty = self.infer_expr(object);
                     let receiver_ty = self.unifier.resolve(receiver_ty);
+                    if let Some(ret) =
+                        self.infer_interface_member_call(receiver_ty, field, args, trailing, None)
+                    {
+                        return ret;
+                    }
                     if let Some(method) = self.lookup_method(receiver_ty, field) {
                         self.record_method_call(expr, method.link_name.clone());
                         self.record_method_call(callee.as_ref(), method.link_name.clone());
@@ -2285,6 +2385,7 @@ impl TypeChecker {
                 ) {
                     ConversionDecision::Identity
                     | ConversionDecision::Coerce
+                    | ConversionDecision::MakeInterfaceObj
                     | ConversionDecision::Cast => target,
                     ConversionDecision::Incompatible => {
                         self.diagnostics.push(
@@ -2459,6 +2560,7 @@ impl TypeChecker {
                 ) {
                     ConversionDecision::Identity
                     | ConversionDecision::Coerce
+                    | ConversionDecision::MakeInterfaceObj
                     | ConversionDecision::Cast => return target,
                     ConversionDecision::Incompatible => {}
                 }
@@ -2703,6 +2805,16 @@ impl TypeChecker {
                 if let Expr::Member { object, field } = TypeChecker::base_expr(callee.as_ref()) {
                     if let Some(receiver_ty) = self.resolve_type_receiver_expr(object) {
                         let receiver_ty = self.unifier.resolve(receiver_ty);
+                        if let Some(actual) = self.infer_interface_member_call(
+                            receiver_ty,
+                            field,
+                            args,
+                            trailing,
+                            Some(expected),
+                        ) {
+                            self.require_assignable(expected, actual, "bidirectional expected type");
+                            return actual;
+                        }
                         if let Some(method) = self.lookup_method(receiver_ty, field) {
                             self.record_method_call(expr, method.link_name.clone());
                             self.record_method_call(callee.as_ref(), method.link_name.clone());
@@ -2720,6 +2832,16 @@ impl TypeChecker {
                     }
                     let receiver_ty = self.infer_expr(object);
                     let receiver_ty = self.unifier.resolve(receiver_ty);
+                    if let Some(actual) = self.infer_interface_member_call(
+                        receiver_ty,
+                        field,
+                        args,
+                        trailing,
+                        Some(expected),
+                    ) {
+                        self.require_assignable(expected, actual, "bidirectional expected type");
+                        return actual;
+                    }
                     if let Some(method) = self.lookup_method(receiver_ty, field) {
                         self.record_method_call(expr, method.link_name.clone());
                         self.record_method_call(callee.as_ref(), method.link_name.clone());
@@ -2821,6 +2943,7 @@ impl TypeChecker {
                 ) {
                     ConversionDecision::Identity
                     | ConversionDecision::Coerce
+                    | ConversionDecision::MakeInterfaceObj
                     | ConversionDecision::Cast => target,
                     ConversionDecision::Incompatible => {
                         self.emit_type_mismatch(
@@ -2956,7 +3079,9 @@ impl TypeChecker {
                                 ConversionMode::ImplicitOnly,
                                 "union payload"
                             ),
-                            ConversionDecision::Identity | ConversionDecision::Coerce
+                            ConversionDecision::Identity
+                                | ConversionDecision::Coerce
+                                | ConversionDecision::MakeInterfaceObj
                         ) {
                             return expected;
                         }
@@ -3240,6 +3365,7 @@ impl TypeChecker {
                 ) {
                     ConversionDecision::Identity
                     | ConversionDecision::Coerce
+                    | ConversionDecision::MakeInterfaceObj
                     | ConversionDecision::Cast => target,
                     ConversionDecision::Incompatible => {
                         self.diagnostics.push(
@@ -3413,13 +3539,17 @@ impl TypeChecker {
 
         if matches!(
             self.conversion_decision(lhs, rhs, ConversionMode::ImplicitOnly, context),
-            ConversionDecision::Identity | ConversionDecision::Coerce
+            ConversionDecision::Identity
+                | ConversionDecision::Coerce
+                | ConversionDecision::MakeInterfaceObj
         ) {
             return lhs;
         }
         if matches!(
             self.conversion_decision(rhs, lhs, ConversionMode::ImplicitOnly, context),
-            ConversionDecision::Identity | ConversionDecision::Coerce
+            ConversionDecision::Identity
+                | ConversionDecision::Coerce
+                | ConversionDecision::MakeInterfaceObj
         ) {
             return rhs;
         }
@@ -3451,6 +3581,9 @@ impl TypeChecker {
                 .iter()
                 .any(|(_, field_ty)| self.type_contains_infer_var(*field_ty)),
             Some(Ty::Interface(members)) => members
+                .iter()
+                .any(|(_, member_ty)| self.type_contains_infer_var(*member_ty)),
+            Some(Ty::InterfaceObject(members)) => members
                 .iter()
                 .any(|(_, member_ty)| self.type_contains_infer_var(*member_ty)),
             Some(Ty::Enum(variants)) => variants
@@ -4325,6 +4458,20 @@ impl TypeChecker {
                     .collect();
                 self.interner.intern(Ty::Struct(out))
             }
+            Ty::Interface(members) => {
+                let out = members
+                    .iter()
+                    .map(|(n, t)| (n.clone(), self.substitute_ty_id(*t, subst)))
+                    .collect();
+                self.interner.intern(Ty::Interface(out))
+            }
+            Ty::InterfaceObject(members) => {
+                let out = members
+                    .iter()
+                    .map(|(n, t)| (n.clone(), self.substitute_ty_id(*t, subst)))
+                    .collect();
+                self.interner.intern(Ty::InterfaceObject(out))
+            }
             Ty::Enum(variants) => {
                 let out = variants
                     .iter()
@@ -4379,7 +4526,9 @@ impl TypeChecker {
         });
         if matches!(
             self.conversion_decision(expected, actual, ConversionMode::ImplicitOnly, context),
-            ConversionDecision::Identity | ConversionDecision::Coerce
+            ConversionDecision::Identity
+                | ConversionDecision::Coerce
+                | ConversionDecision::MakeInterfaceObj
         ) {
             return;
         }
@@ -4432,7 +4581,9 @@ impl TypeChecker {
                             ConversionMode::ImplicitOnly,
                             &context,
                         ),
-                        ConversionDecision::Identity | ConversionDecision::Coerce
+                        ConversionDecision::Identity
+                            | ConversionDecision::Coerce
+                            | ConversionDecision::MakeInterfaceObj
                     ) {
                         self.obligation_stack = prev_obligations;
                         self.current_expr_span = prev_span;
@@ -4491,7 +4642,9 @@ impl TypeChecker {
                             ConversionMode::ImplicitOnly,
                             &context,
                         ),
-                        ConversionDecision::Identity | ConversionDecision::Coerce
+                        ConversionDecision::Identity
+                            | ConversionDecision::Coerce
+                            | ConversionDecision::MakeInterfaceObj
                     ) {
                         self.obligation_stack = prev_obligations;
                         self.current_expr_span = prev_span;
@@ -4866,6 +5019,12 @@ impl TypeChecker {
                 to: expected,
                 expr: Box::new(expr),
             },
+            ConversionDecision::MakeInterfaceObj => CheckedExpr::MakeInterfaceObj {
+                expr: Box::new(expr),
+                interface_ty: expected,
+                concrete_ty: actual,
+                method_links: self.interface_method_links(actual, expected),
+            },
             ConversionDecision::Cast => CheckedExpr::Cast {
                 from: actual,
                 to: expected,
@@ -4921,7 +5080,10 @@ impl TypeChecker {
                 .interface_failure_for_interface_ty(actual, expected)
                 .is_none()
             {
-                return ConversionDecision::Identity;
+                if matches!(actual_ty, Ty::Interface(_) | Ty::InterfaceObject(_)) {
+                    return ConversionDecision::Identity;
+                }
+                return ConversionDecision::MakeInterfaceObj;
             }
             return ConversionDecision::Incompatible;
         }
@@ -5608,6 +5770,20 @@ impl TypeChecker {
                     .cloned()
                     .or_else(|| self.resolved_method_call(callee.as_ref()).cloned());
                 if let Expr::Member { object, field } = TypeChecker::base_expr(callee.as_ref()) {
+                    let receiver_preview = self.preview_expr_ty(object);
+                    let receiver_ty = self.unifier.resolve(receiver_preview);
+                    if let Some((method_index, _, ret_ty)) =
+                        self.interface_method_sig(receiver_ty, field)
+                    {
+                        return CheckedExpr::InterfaceCall {
+                            receiver: Box::new(self.lower_expr(object)),
+                            interface_ty: receiver_ty,
+                            method: field.clone(),
+                            method_index,
+                            args: args.iter().map(|a| self.lower_expr(a)).collect(),
+                            ret_ty,
+                        };
+                    }
                     let method_link_name = resolved_method.or_else(|| {
                         let receiver_ty = self.preview_expr_ty(object);
                         let receiver_ty = self.unifier.resolve(receiver_ty);
@@ -5694,6 +5870,12 @@ impl TypeChecker {
                         from: source_ty,
                         to: target_ty,
                         expr: Box::new(self.lower_expr(expr)),
+                    },
+                    ConversionDecision::MakeInterfaceObj => CheckedExpr::MakeInterfaceObj {
+                        expr: Box::new(self.lower_expr(expr)),
+                        interface_ty: target_ty,
+                        concrete_ty: source_ty,
+                        method_links: self.interface_method_links(source_ty, target_ty),
                     },
                     ConversionDecision::Cast | ConversionDecision::Incompatible => {
                         CheckedExpr::Cast {
@@ -6097,6 +6279,7 @@ impl TypeChecker {
                 ) {
                     ConversionDecision::Identity
                     | ConversionDecision::Coerce
+                    | ConversionDecision::MakeInterfaceObj
                     | ConversionDecision::Cast => target,
                     ConversionDecision::Incompatible => self.unknown_ty(),
                 }
@@ -6358,7 +6541,7 @@ fn ty_to_ref(ty: &Ty, interner: &TyInterner) -> TypeRef {
                 .collect::<Vec<_>>();
             TypeRef::Union(refs)
         }
-        Ty::Interface(members) => {
+        Ty::Interface(members) | Ty::InterfaceObject(members) => {
             let refs = members
                 .iter()
                 .map(|(name, id)| {
@@ -9154,6 +9337,44 @@ mod tests {
             .diagnostics
             .iter()
             .any(|d| d.code_str() == "E_INTERFACE_METHOD_MISMATCH"));
+    }
+
+    #[test]
+    fn empty_interface_annotation_resolves_as_any_type() {
+        let src = r#"
+            def x: interface() = 1
+        "#;
+        let parsed = Parser::parse_source(src).expect("parse should succeed");
+        let checked = check_module(&parsed);
+        let module = checked.module.expect("module should exist");
+        let x_ty = module.value_types.get("x").copied().expect("x should be typed");
+        assert!(matches!(module.types.get(x_ty), Some(Ty::Any)));
+    }
+
+    #[test]
+    fn named_interface_alias_lowers_member_signature_to_interface_ty() {
+        let src = r#"
+            def ToDouble = interface(double: Func[(), Int]);
+            def Int.double() -> Int { 2 }
+            def x: ToDouble = 1
+        "#;
+        let parsed = Parser::parse_source(src).expect("parse should succeed");
+        let checked = check_module(&parsed);
+        let module = checked.module.expect("module should exist");
+        let alias_ty = module
+            .type_aliases
+            .get("ToDouble")
+            .copied()
+            .expect("ToDouble alias should exist");
+        let Some(Ty::Interface(members)) = module.types.get(alias_ty) else {
+            panic!("ToDouble should lower to Ty::Interface");
+        };
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].0, "double");
+        let Some(Ty::Func { params, .. }) = module.types.get(members[0].1) else {
+            panic!("double member should lower to function type");
+        };
+        assert!(params.is_empty(), "double signature should have no args");
     }
 
     #[test]

--- a/crates/aura-typecheck/src/generics.rs
+++ b/crates/aura-typecheck/src/generics.rs
@@ -33,7 +33,22 @@ impl GenericChecker {
                     let name = match interface {
                         TypeExpr::Named { name, .. } => name.as_str(),
                         TypeExpr::Interface(_) => "interface",
-                        _ => continue,
+                        other => {
+                            diagnostics.push(
+                                Diagnostic::error(Issue::UnknownInterface)
+                                    .with_related(
+                                        format!(
+                                            "generic parameter '{}' uses unsupported interface constraint form: {:?}",
+                                            param.name, other
+                                        ),
+                                        None,
+                                    )
+                                    .with_hint(
+                                        "use a named interface alias or `interface(...)` constraint",
+                                    ),
+                            );
+                            continue;
+                        }
                     };
                     if !self.interfaces.contains(name) {
                         diagnostics.push(
@@ -144,5 +159,23 @@ mod tests {
             &[StaticArg::Value(StaticValueExpr::Int("4".to_string()))],
         );
         assert!(ok.is_empty());
+    }
+
+    #[test]
+    fn malformed_interface_constraint_form_reports_diagnostic() {
+        let checker = GenericChecker::new();
+        let params = vec![GenericParam {
+            name: "T".to_string(),
+            constraints: vec![GenericConstraint::Interface(TypeExpr::Static(Box::new(
+                TypeExpr::Named {
+                    name: "Int".to_string(),
+                    args: Vec::new(),
+                },
+            )))],
+        }];
+
+        let diagnostics = checker.validate_constraints(&params);
+        assert!(!diagnostics.is_empty());
+        assert_eq!(diagnostics[0].code_str(), "E_UNKNOWN_INTERFACE");
     }
 }

--- a/crates/aura-typecheck/src/generics.rs
+++ b/crates/aura-typecheck/src/generics.rs
@@ -5,7 +5,7 @@ use crate::interfaces::InterfaceRegistry;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GenericConstraint {
-    Interface(String),
+    Interface(TypeExpr),
     Static(TypeExpr),
 }
 
@@ -29,7 +29,12 @@ impl GenericChecker {
         let mut diagnostics = Vec::new();
         for param in params {
             for constraint in &param.constraints {
-                if let GenericConstraint::Interface(name) = constraint {
+                if let GenericConstraint::Interface(interface) = constraint {
+                    let name = match interface {
+                        TypeExpr::Named { name, .. } => name.as_str(),
+                        TypeExpr::Interface(_) => "interface",
+                        _ => continue,
+                    };
                     if !self.interfaces.contains(name) {
                         diagnostics.push(
                             Diagnostic::error(Issue::UnknownInterface)
@@ -105,7 +110,10 @@ mod tests {
         let checker = GenericChecker::new();
         let params = vec![GenericParam {
             name: "T".to_string(),
-            constraints: vec![GenericConstraint::Interface("Mystery".to_string())],
+            constraints: vec![GenericConstraint::Interface(TypeExpr::Named {
+                name: "Mystery".to_string(),
+                args: Vec::new(),
+            })],
         }];
 
         let diagnostics = checker.validate_constraints(&params);

--- a/crates/aura-typecheck/src/interfaces.rs
+++ b/crates/aura-typecheck/src/interfaces.rs
@@ -9,6 +9,7 @@ impl InterfaceRegistry {
     pub fn with_prelude() -> Self {
         let mut known = HashSet::new();
         for name in [
+            "interface",
             "Eq",
             "Hash",
             "Show",

--- a/crates/aura-typecheck/src/types.rs
+++ b/crates/aura-typecheck/src/types.rs
@@ -69,6 +69,7 @@ pub enum Ty {
     Struct(Vec<(String, TyId)>),
     Union(Vec<TyId>),
     Interface(Vec<(String, TyId)>),
+    InterfaceObject(Vec<(String, TyId)>),
     Enum(Vec<(String, Option<TyId>)>),
 }
 

--- a/crates/aura-typecheck/src/types.rs
+++ b/crates/aura-typecheck/src/types.rs
@@ -68,6 +68,7 @@ pub enum Ty {
     Tuple(Vec<TyId>),
     Struct(Vec<(String, TyId)>),
     Union(Vec<TyId>),
+    Interface(Vec<(String, TyId)>),
     Enum(Vec<(String, Option<TyId>)>),
 }
 

--- a/crates/aura-typecheck/tests/diagnostics_snapshot.rs
+++ b/crates/aura-typecheck/tests/diagnostics_snapshot.rs
@@ -73,6 +73,38 @@ fn snapshot_interface_bound_unsatisfied_shape() {
 }
 
 #[test]
+fn snapshot_interface_missing_method_shape() {
+    let src = "def NeedsDouble = interface(double: Func[(), Int]); def[T: NeedsDouble] f(x: T) -> T { x }; def y = f[Int](1)";
+    let parsed = Parser::parse_source(src).expect("parse should succeed");
+    let checked = check_module(&parsed);
+    let diag = checked
+        .diagnostics
+        .iter()
+        .find(|d| d.code_str() == "E_INTERFACE_METHOD_MISSING")
+        .expect("expected interface method missing diagnostic");
+
+    let got = render(diag);
+    assert!(got.contains("error|typecheck|E_INTERFACE_METHOD_MISSING|"));
+    assert!(got.contains("missing interface method `double`"));
+}
+
+#[test]
+fn snapshot_interface_signature_mismatch_shape() {
+    let src = "def NeedsDouble = interface(double: Func[(), Int]); def Int.double() -> Float { 2.0 }; def[T: NeedsDouble] f(x: T) -> T { x }; def y = f[Int](1)";
+    let parsed = Parser::parse_source(src).expect("parse should succeed");
+    let checked = check_module(&parsed);
+    let diag = checked
+        .diagnostics
+        .iter()
+        .find(|d| d.code_str() == "E_INTERFACE_METHOD_MISMATCH")
+        .expect("expected interface method mismatch diagnostic");
+
+    let got = render(diag);
+    assert!(got.contains("error|typecheck|E_INTERFACE_METHOD_MISMATCH|"));
+    assert!(got.contains("incompatible signature"));
+}
+
+#[test]
 fn snapshot_type_mismatch_return_shape() {
     let src = "def f(x: Int) -> Int { \"bad\" }";
     let parsed = Parser::parse_source(src).expect("parse should succeed");

--- a/crates/aura-typecheck/tests/ir_contract_snapshot.rs
+++ b/crates/aura-typecheck/tests/ir_contract_snapshot.rs
@@ -132,6 +132,10 @@ fn semantically_checked_ir_has_no_any_nodes_for_core_operator_path() {
             }
             CheckedExpr::Coerce { expr, .. } => contains_any(expr),
             CheckedExpr::Cast { expr, .. } => contains_any(expr),
+            CheckedExpr::MakeInterfaceObj { expr, .. } => contains_any(expr),
+            CheckedExpr::InterfaceCall { receiver, args, .. } => {
+                contains_any(receiver) || args.iter().any(contains_any)
+            }
             CheckedExpr::Continue { .. }
             | CheckedExpr::Ident(_)
             | CheckedExpr::Int(_)
@@ -287,6 +291,10 @@ fn pipe_operator_consumes_placeholder_in_rhs_call_without_any_nodes() {
             }
             CheckedExpr::Coerce { expr, .. } => contains_any(expr),
             CheckedExpr::Cast { expr, .. } => contains_any(expr),
+            CheckedExpr::MakeInterfaceObj { expr, .. } => contains_any(expr),
+            CheckedExpr::InterfaceCall { receiver, args, .. } => {
+                contains_any(receiver) || args.iter().any(contains_any)
+            }
             CheckedExpr::Continue { .. }
             | CheckedExpr::Ident(_)
             | CheckedExpr::Int(_)
@@ -397,6 +405,10 @@ fn enum_constructor_forms_typecheck_without_any_nodes() {
             }
             CheckedExpr::Coerce { expr, .. } => contains_any(expr),
             CheckedExpr::Cast { expr, .. } => contains_any(expr),
+            CheckedExpr::MakeInterfaceObj { expr, .. } => contains_any(expr),
+            CheckedExpr::InterfaceCall { receiver, args, .. } => {
+                contains_any(receiver) || args.iter().any(contains_any)
+            }
             CheckedExpr::Continue { .. }
             | CheckedExpr::Ident(_)
             | CheckedExpr::Int(_)
@@ -548,6 +560,10 @@ fn struct_payload_enum_sugar_lowers_to_single_struct_payload() {
             CheckedExpr::Coerce { expr, .. } | CheckedExpr::Cast { expr, .. } => {
                 contains_any_or_dot_ident(expr)
             }
+            CheckedExpr::MakeInterfaceObj { expr, .. } => contains_any_or_dot_ident(expr),
+            CheckedExpr::InterfaceCall { receiver, args, .. } => {
+                contains_any_or_dot_ident(receiver) || args.iter().any(contains_any_or_dot_ident)
+            }
             CheckedExpr::Continue { .. }
             | CheckedExpr::Ident(_)
             | CheckedExpr::Int(_)
@@ -616,4 +632,35 @@ fn enum_match_struct_payload_pattern_records_field_bindings() {
     assert_eq!(err_arm.struct_bindings[0].field_index, 0);
     assert_eq!(err_arm.struct_bindings[1].name, "status");
     assert_eq!(err_arm.struct_bindings[1].field_index, 1);
+}
+
+#[test]
+fn interface_values_lower_with_runtime_object_and_dynamic_dispatch_nodes() {
+    let src = r#"
+        def ToDouble = interface(double: Func[(), ISize]);
+        def Int.double() -> ISize { 2 }
+        def call(x: ToDouble) -> ISize { x.double() }
+        def value: ToDouble = 1;
+        def main() -> Void {
+            call(value);
+            ()
+        }
+    "#;
+    let parsed = Parser::parse_source(src).expect("parse should succeed");
+    let checked = check_module(&parsed);
+    let module = checked
+        .module
+        .unwrap_or_else(|| panic!("module should exist: {:?}", checked.diagnostics));
+
+    let call_decl = module
+        .ir
+        .declarations
+        .iter()
+        .find(|decl| decl.name == "call")
+        .expect("call function should exist");
+    assert!(matches!(
+        call_decl.value,
+        CheckedExpr::InterfaceCall { .. }
+    ));
+
 }

--- a/docs/Contracts/Typecheck IR.md
+++ b/docs/Contracts/Typecheck IR.md
@@ -49,6 +49,8 @@ Status: frozen v1.
 - `CheckedStaticArg`
 - `CheckedTypeExpr`
 - `CheckedStaticValue`
+- `CheckedTypeExpr::Interface(Vec<(String, CheckedTypeExpr)>)` preserves source interface members as first-class metadata.
+- `interface()` and `Any` are equivalent at type resolution boundaries.
 
 ## Invariants (Frozen v1)
 

--- a/docs/Contracts/Typecheck IR.md
+++ b/docs/Contracts/Typecheck IR.md
@@ -51,6 +51,9 @@ Status: frozen v1.
 - `CheckedStaticValue`
 - `CheckedTypeExpr::Interface(Vec<(String, CheckedTypeExpr)>)` preserves source interface members as first-class metadata.
 - `interface()` and `Any` are equivalent at type resolution boundaries.
+- Runtime interface dispatch is represented explicitly in checked IR:
+  - `CheckedExpr::MakeInterfaceObj` marks interface object construction/coercion sites.
+  - `CheckedExpr::InterfaceCall` marks dynamic dispatch calls against interface-typed receivers.
 - Interface constraint solving is structural and method-set based. Missing required methods and incompatible method signatures emit dedicated diagnostics.
 
 ## Invariants (Frozen v1)

--- a/docs/Contracts/Typecheck IR.md
+++ b/docs/Contracts/Typecheck IR.md
@@ -51,6 +51,7 @@ Status: frozen v1.
 - `CheckedStaticValue`
 - `CheckedTypeExpr::Interface(Vec<(String, CheckedTypeExpr)>)` preserves source interface members as first-class metadata.
 - `interface()` and `Any` are equivalent at type resolution boundaries.
+- Interface constraint solving is structural and method-set based. Missing required methods and incompatible method signatures emit dedicated diagnostics.
 
 ## Invariants (Frozen v1)
 

--- a/docs/Generated/Commands Inventory.md
+++ b/docs/Generated/Commands Inventory.md
@@ -2,7 +2,7 @@
 title: Commands Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:49:58.059351Z
+generated_at: 2026-05-03T18:53:52.5470381Z
 ---
 
 # Commands Inventory

--- a/docs/Generated/Commands Inventory.md
+++ b/docs/Generated/Commands Inventory.md
@@ -2,7 +2,7 @@
 title: Commands Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:26:54.8221881Z
+generated_at: 2026-05-03T18:49:58.059351Z
 ---
 
 # Commands Inventory

--- a/docs/Generated/Directory Inventory.md
+++ b/docs/Generated/Directory Inventory.md
@@ -2,7 +2,7 @@
 title: Directory Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:49:58.059351Z
+generated_at: 2026-05-03T18:53:52.5470381Z
 ---
 
 # Directory Inventory

--- a/docs/Generated/Directory Inventory.md
+++ b/docs/Generated/Directory Inventory.md
@@ -2,7 +2,7 @@
 title: Directory Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:26:54.8221881Z
+generated_at: 2026-05-03T18:49:58.059351Z
 ---
 
 # Directory Inventory

--- a/docs/Generated/Examples Inventory.md
+++ b/docs/Generated/Examples Inventory.md
@@ -2,7 +2,7 @@
 title: Examples Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:26:54.8221881Z
+generated_at: 2026-05-03T18:49:58.059351Z
 ---
 
 # Examples Inventory

--- a/docs/Generated/Examples Inventory.md
+++ b/docs/Generated/Examples Inventory.md
@@ -2,7 +2,7 @@
 title: Examples Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:49:58.059351Z
+generated_at: 2026-05-03T18:53:52.5470381Z
 ---
 
 # Examples Inventory

--- a/docs/Generated/Test Inventory.md
+++ b/docs/Generated/Test Inventory.md
@@ -2,7 +2,7 @@
 title: Test Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:49:58.059351Z
+generated_at: 2026-05-03T18:53:52.5470381Z
 ---
 
 # Test Inventory

--- a/docs/Generated/Test Inventory.md
+++ b/docs/Generated/Test Inventory.md
@@ -2,7 +2,7 @@
 title: Test Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:26:54.8221881Z
+generated_at: 2026-05-03T18:49:58.059351Z
 ---
 
 # Test Inventory

--- a/docs/Generated/Workspace Inventory.md
+++ b/docs/Generated/Workspace Inventory.md
@@ -2,7 +2,7 @@
 title: Workspace Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:26:54.8221881Z
+generated_at: 2026-05-03T18:49:58.059351Z
 ---
 
 # Workspace Inventory

--- a/docs/Generated/Workspace Inventory.md
+++ b/docs/Generated/Workspace Inventory.md
@@ -2,7 +2,7 @@
 title: Workspace Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-05-03T18:49:58.059351Z
+generated_at: 2026-05-03T18:53:52.5470381Z
 ---
 
 # Workspace Inventory

--- a/docs/Language/Syntax And Semantics.md
+++ b/docs/Language/Syntax And Semantics.md
@@ -28,6 +28,7 @@ This note is a reader's map into `DESIGN.md`, not a replacement for it.
 - `true`, `false`, and `null` are not reserved keywords; Aura treats them as runtime aliases, matching `.true`, `.false`, and `.null`
 - AUON phase 1 reuses those alias spellings as source-level conveniences and normalizes them to dot-variant values
 - Generic type aliases preserve static parameters: `def[T] Box = (value: T)` can be used as `Box[Int]`, including when imported from a dependency entrypoint.
+- `interface(...)` is a dedicated type form in the compiler pipeline, and `interface()` remains equivalent to `Any`.
 
 ## Managed Memory Surface
 

--- a/docs/Language/Syntax And Semantics.md
+++ b/docs/Language/Syntax And Semantics.md
@@ -29,6 +29,7 @@ This note is a reader's map into `DESIGN.md`, not a replacement for it.
 - AUON phase 1 reuses those alias spellings as source-level conveniences and normalizes them to dot-variant values
 - Generic type aliases preserve static parameters: `def[T] Box = (value: T)` can be used as `Box[Int]`, including when imported from a dependency entrypoint.
 - `interface(...)` is a dedicated type form in the compiler pipeline, and `interface()` remains equivalent to `Any`.
+- Interface constraints are structural: a type satisfies an interface when its receiver method set matches required method names/signatures.
 
 ## Managed Memory Surface
 

--- a/docs/Subsystems/Codegen.md
+++ b/docs/Subsystems/Codegen.md
@@ -70,6 +70,12 @@ Struct and tuple literals lower to aggregate storage pointers in LLVM. Aggregate
 
 `!!` force unwrap now follows the shared panic path on failure instead of lowering directly to an unconditional trap.
 
+Interface runtime lowering uses a two-pointer object ABI in LLVM codegen:
+- data pointer (points to stored concrete receiver value)
+- vtable/witness pointer (method function-pointer slots)
+
+`CheckedExpr::MakeInterfaceObj` allocates and initializes that object shape, and `CheckedExpr::InterfaceCall` performs indirect-call lowering through the vtable slot for the selected interface method.
+
 ## Testing
 
 LLVM-specific validation runs through `cargo xtask llvm ...`.

--- a/docs/Subsystems/Runtime Host.md
+++ b/docs/Subsystems/Runtime Host.md
@@ -84,6 +84,10 @@ The exported helpers use this object model:
 
 Generated code treats `RawAlloc[T]`, `Slice[T]`, and `Ref[T]` as opaque pointer-shaped handles. The runtime host owns the concrete structs and stores managed allocation bytes in zero-initialized leak-only storage.
 
+### Interface object ABI (compiler-side)
+
+Compiler-generated LLVM IR represents interface values as a data pointer plus a vtable/witness pointer. The runtime host does not currently expose dedicated helper symbols for interface objects; dispatch support is emitted directly by codegen.
+
 - `raw_alloc_new(count, elem_size, elem_align, layout_id, trace_kind)` allocates process-lifetime storage for `count` elements and records GC-prep metadata.
 - `raw_alloc_slice(alloc)` creates an opaque full-allocation slice handle.
 - `slice_get(slice, index, out)` copies one element into compiler-provided stack storage and returns `false` when out of bounds.

--- a/docs/Subsystems/Typecheck.md
+++ b/docs/Subsystems/Typecheck.md
@@ -59,6 +59,8 @@ Resolve symbols, enforce type rules, and emit checked IR for downstream codegen.
 - Assignment-form type aliases preserve static parameters: `def[T] Box = (value: T)` records an alias scheme.
 - Alias schemes instantiate during type resolution, so `Box[Int]` resolves under a temporary generic scope where `T = Int`.
 - Monomorphic aliases export as concrete `TypeRef`s. Generic aliases export their source-level alias scheme through `CheckContext` so consumers can instantiate imported aliases such as `Box[Int]`.
+- Interface types are represented as first-class type nodes in checker/type IR (`interface(...)` is not lowered as a nominal fallback name).
+- Empty interface `interface()` resolves equivalently to `Any`.
 
 ## Checked IR Notes
 

--- a/docs/Subsystems/Typecheck.md
+++ b/docs/Subsystems/Typecheck.md
@@ -61,6 +61,8 @@ Resolve symbols, enforce type rules, and emit checked IR for downstream codegen.
 - Monomorphic aliases export as concrete `TypeRef`s. Generic aliases export their source-level alias scheme through `CheckContext` so consumers can instantiate imported aliases such as `Box[Int]`.
 - Interface types are represented as first-class type nodes in checker/type IR (`interface(...)` is not lowered as a nominal fallback name).
 - Empty interface `interface()` resolves equivalently to `Any`.
+- Interface bounds are enforced structurally via receiver method sets (`lookup_method` + receiver matching), including named interface aliases and anonymous `interface(...)` constraints.
+- Typecheck now emits dedicated diagnostics for structural failures: missing required interface methods and method signature mismatches.
 
 ## Checked IR Notes
 

--- a/docs/Subsystems/Typecheck.md
+++ b/docs/Subsystems/Typecheck.md
@@ -63,6 +63,8 @@ Resolve symbols, enforce type rules, and emit checked IR for downstream codegen.
 - Empty interface `interface()` resolves equivalently to `Any`.
 - Interface bounds are enforced structurally via receiver method sets (`lookup_method` + receiver matching), including named interface aliases and anonymous `interface(...)` constraints.
 - Typecheck now emits dedicated diagnostics for structural failures: missing required interface methods and method signature mismatches.
+- Interface-typed value conversions now lower through `CheckedExpr::MakeInterfaceObj` when a concrete value is assigned/coerced into an interface type.
+- Interface member calls on interface-typed receivers lower through `CheckedExpr::InterfaceCall` rather than the direct static `CheckedExpr::Call` path.
 
 ## Checked IR Notes
 

--- a/e2e/interface-missing-method-fail/project.auon
+++ b/e2e/interface-missing-method-fail/project.auon
@@ -1,0 +1,4 @@
+name = "e2e/interface-missing-method-fail",
+version = "0.1.0",
+kind = .binary,
+dependencies = []

--- a/e2e/interface-missing-method-fail/src/main.aura
+++ b/e2e/interface-missing-method-fail/src/main.aura
@@ -1,0 +1,8 @@
+def NeedsDouble = interface(double: Func[(), Int]);
+
+def[T: NeedsDouble] identity(x: T) -> T { x }
+
+def main() -> Void {
+    identity[Int](1);
+    ()
+}

--- a/e2e/interface-runtime-dispatch-pass/project.auon
+++ b/e2e/interface-runtime-dispatch-pass/project.auon
@@ -1,0 +1,4 @@
+name = "e2e/interface-runtime-dispatch-pass",
+version = "0.1.0",
+kind = .binary,
+dependencies = []

--- a/e2e/interface-runtime-dispatch-pass/src/main.aura
+++ b/e2e/interface-runtime-dispatch-pass/src/main.aura
@@ -1,0 +1,12 @@
+def ToDouble = interface(double: Func[(), ISize]);
+def Int.double() -> ISize { 2 }
+
+def call(x: ToDouble) -> ISize { x.double() }
+
+def make_value() -> ToDouble { 1 }
+
+def main() -> Void {
+    let value = make_value();
+    call(value);
+    ()
+}

--- a/e2e/interface-signature-mismatch-fail/project.auon
+++ b/e2e/interface-signature-mismatch-fail/project.auon
@@ -1,0 +1,4 @@
+name = "e2e/interface-signature-mismatch-fail",
+version = "0.1.0",
+kind = .binary,
+dependencies = []

--- a/e2e/interface-signature-mismatch-fail/src/main.aura
+++ b/e2e/interface-signature-mismatch-fail/src/main.aura
@@ -1,0 +1,9 @@
+def NeedsDouble = interface(double: Func[(), Int]);
+def Int.double() -> Float { 2.0 }
+
+def[T: NeedsDouble] identity(x: T) -> T { x }
+
+def main() -> Void {
+    identity[Int](1);
+    ()
+}

--- a/e2e/interface-structural-pass/project.auon
+++ b/e2e/interface-structural-pass/project.auon
@@ -1,0 +1,4 @@
+name = "e2e/interface-structural-pass",
+version = "0.1.0",
+kind = .binary,
+dependencies = []

--- a/e2e/interface-structural-pass/src/main.aura
+++ b/e2e/interface-structural-pass/src/main.aura
@@ -1,0 +1,9 @@
+def NeedsDouble = interface(double: Func[(), Int]);
+def Int.double() -> Int { 2 }
+
+def[T: NeedsDouble] identity(x: T) -> T { x }
+
+def main() -> Void {
+    identity[Int](1);
+    ()
+}


### PR DESCRIPTION
## Summary
- model `interface(...)` as a first-class type across frontend AST/parser, typecheck IR, and diagnostics/codegen type references
- preserve `interface()` equivalence with `Any` and add parser coverage for interface aliases/annotations/empty forms
- implement Draft 2 structural interface satisfaction using receiver method sets, including named interface aliases and anonymous `interface(...)` constraints
- add dedicated diagnostics for structural failures (`E_INTERFACE_METHOD_MISSING`, `E_INTERFACE_METHOD_MISMATCH`) with snapshot and checker coverage
- add Draft 2 e2e fixtures for pass/fail structural interface behavior and update DESIGN/typecheck docs with structural semantics
- add Draft 3 runtime interface dispatch IR nodes (`MakeInterfaceObj`, `InterfaceCall`) and checker lowering paths for interface-typed method calls
- implement LLVM-side interface object ABI lowering (data pointer + vtable pointer), generated interface dispatch thunks, and indirect-call dispatch
- add runtime interface dispatch coverage in IR contract tests, LLVM module tests, and a new e2e fixture (`e2e/interface-runtime-dispatch-pass`)

## Test plan
- [x] `cargo xtask dev check`
- [x] `cargo xtask dev test`
- [x] `cargo xtask docs sync`
- [x] `cargo xtask docs check`
- [x] `cargo run -p aura-cli -- build --format auir e2e/interface-structural-pass/src/main.aura`
- [x] `cargo run -p aura-cli -- build --format auir e2e/interface-missing-method-fail/src/main.aura` (expected fail with `E_INTERFACE_METHOD_MISSING`)
- [x] `cargo run -p aura-cli -- build --format auir e2e/interface-signature-mismatch-fail/src/main.aura` (expected fail with `E_INTERFACE_METHOD_MISMATCH`)
- [x] `cargo xtask llvm run -- -p aura-cli -- build e2e/interface-runtime-dispatch-pass`
- [x] `cargo xtask llvm cargo -- check -p aura-codegen --features llvm-backend`

Made with [Cursor](https://cursor.com)
