### PR TITLE
feat: panic/catch support (issue 31)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1412,8 +1412,19 @@ defstub string_into: Func[(text: String), Bytes];
 of bytes written. The current host implementation recognizes `1` as stdout and `2` as stderr; it
 returns `-1` on host write failure.
 
-`Bytes.get` and `Bytes.set` are intentionally unchecked for now. Out-of-bounds access is undefined
-behavior until panic handlers exist.
+`Bytes.get` and `Bytes.set` perform runtime bounds checks. Out-of-bounds access now routes through
+the panic path.
+
+Aura provides panic primitives:
+
+```aura
+panic "something went wrong"
+let recovered = catch (panic "boom") else { "fallback" }
+```
+
+- `panic "message"` raises a runtime panic with a string payload.
+- `catch (expr) else { fallback }` evaluates `expr` in a guarded region and returns `fallback` if
+  panic is raised while evaluating `expr`.
 
 `String` remains the public string-literal type; converting it to a writeable buffer requires
 `String.into()`, which copies the UTF-8 bytes into a fresh owned `Bytes` value.

--- a/crates/aura-codegen/src/llvm/expr.rs
+++ b/crates/aura-codegen/src/llvm/expr.rs
@@ -47,6 +47,8 @@ pub fn classify_expr_kind(expr: &CheckedExpr) -> &'static str {
         CheckedExpr::AssignLocal { .. } => "assign_local",
         CheckedExpr::FieldAccess { .. } => "field_access",
         CheckedExpr::ForceUnwrap { .. } => "force_unwrap",
+        CheckedExpr::Panic { .. } => "panic",
+        CheckedExpr::Catch { .. } => "catch",
         CheckedExpr::AssignField { .. } => "assign_field",
         CheckedExpr::Closure { .. } => "closure",
         CheckedExpr::Any => "any",
@@ -187,6 +189,12 @@ pub fn lower_expr<'ctx, 'm>(
             payload_ty,
             payload_variant_index,
         } => lower_force_unwrap(cg, expr, *enum_ty, *payload_ty, *payload_variant_index),
+        CheckedExpr::Panic { message } => lower_panic_expr(cg, message),
+        CheckedExpr::Catch {
+            result_ty,
+            expr,
+            fallback,
+        } => lower_catch_expr(cg, *result_ty, expr, fallback),
         CheckedExpr::AssignField {
             object,
             object_ty,
@@ -1045,10 +1053,15 @@ fn lower_force_unwrap<'ctx, 'm>(
         .ok_or(CodegenError::UnsupportedExpression("force_unwrap"))?;
     let enum_basic_ty =
         lower_basic_type(cg.context, &cg.checked.types, enum_ty)?.into_struct_type();
+    let payload_basic_ty = lower_basic_type(cg.context, &cg.checked.types, payload_ty)?;
     let value = lower_expr(cg, expr)?;
     let slot = cg
         .builder
         .build_alloca(enum_basic_ty, "force_unwrap_value")
+        .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))?;
+    let result_slot = cg
+        .builder
+        .build_alloca(payload_basic_ty, "force_unwrap_result")
         .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))?;
     cg.builder
         .build_store(slot, value)
@@ -1064,15 +1077,157 @@ fn lower_force_unwrap<'ctx, 'm>(
         .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))?;
     let some_block = cg.context.append_basic_block(function, "force_unwrap_some");
     let null_block = cg.context.append_basic_block(function, "force_unwrap_null");
+    let merge_block = cg.context.append_basic_block(function, "force_unwrap_merge");
     cg.builder
         .build_conditional_branch(ok, some_block, null_block)
         .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))?;
     cg.builder.position_at_end(null_block);
+    let panic_message = CheckedExpr::String("force unwrap failed".to_string());
+    let _ = lower_panic_expr(cg, &panic_message)?;
     cg.builder
-        .build_unreachable()
+        .build_store(result_slot, payload_basic_ty.const_zero())
+        .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))?;
+    cg.builder
+        .build_unconditional_branch(merge_block)
         .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))?;
     cg.builder.position_at_end(some_block);
-    load_enum_payload(cg, slot, enum_basic_ty, payload_ty)
+    let payload = load_enum_payload(cg, slot, enum_basic_ty, payload_ty)?;
+    cg.builder
+        .build_store(result_slot, payload)
+        .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))?;
+    cg.builder
+        .build_unconditional_branch(merge_block)
+        .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))?;
+    cg.builder.position_at_end(merge_block);
+    cg.builder
+        .build_load(payload_basic_ty, result_slot, "force_unwrap_result_load")
+        .map_err(|_| CodegenError::UnsupportedExpression("force_unwrap"))
+}
+
+#[cfg(feature = "llvm-backend")]
+fn lower_panic_expr<'ctx, 'm>(
+    cg: &CodegenContext<'ctx, 'm>,
+    message: &CheckedExpr,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let panic_fn = if let Some(function) = cg.module.get_function("aura_panic") {
+        function
+    } else {
+        let Some(fn_ty) = runtime_builtin_function_type(cg, "aura_panic") else {
+            return Err(CodegenError::UnsupportedExpression("panic"));
+        };
+        cg.module
+            .add_function("aura_panic", fn_ty, Some(Linkage::External))
+    };
+    let msg_value = lower_expr(cg, message)?;
+    let args = [BasicMetadataValueEnum::from(msg_value)];
+    cg.builder
+        .build_call(panic_fn, &args, "call_aura_panic")
+        .map_err(|_| CodegenError::UnsupportedExpression("panic"))?;
+    Ok(cg
+        .context
+        .ptr_type(AddressSpace::default())
+        .const_null()
+        .as_basic_value_enum())
+}
+
+#[cfg(feature = "llvm-backend")]
+fn lower_catch_expr<'ctx, 'm>(
+    cg: &CodegenContext<'ctx, 'm>,
+    result_ty: aura_typecheck::TyId,
+    expr: &CheckedExpr,
+    fallback: &CheckedExpr,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let current_block = cg
+        .builder
+        .get_insert_block()
+        .ok_or(CodegenError::UnsupportedExpression("catch"))?;
+    let function = current_block
+        .get_parent()
+        .ok_or(CodegenError::UnsupportedExpression("catch"))?;
+    let then_block = cg.context.append_basic_block(function, "catch_ok");
+    let else_block = cg.context.append_basic_block(function, "catch_fallback");
+    let merge_block = cg.context.append_basic_block(function, "catch_merge");
+
+    let has_result = !matches!(cg.checked.types.get(result_ty), Some(Ty::Void | Ty::Never));
+    let result_slot = if has_result {
+        let result_basic_ty = lower_basic_type(cg.context, &cg.checked.types, result_ty)?;
+        Some(
+            cg.builder
+                .build_alloca(result_basic_ty, "catch_result")
+                .map_err(|_| CodegenError::UnsupportedExpression("catch"))?,
+        )
+    } else {
+        None
+    };
+
+    let begin_fn = if let Some(function) = cg.module.get_function("aura_catch_begin") {
+        function
+    } else {
+        let Some(fn_ty) = runtime_builtin_function_type(cg, "aura_catch_begin") else {
+            return Err(CodegenError::UnsupportedExpression("catch"));
+        };
+        cg.module
+            .add_function("aura_catch_begin", fn_ty, Some(Linkage::External))
+    };
+    cg.builder
+        .build_call(begin_fn, &[], "call_aura_catch_begin")
+        .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
+
+    let try_value = lower_expr(cg, expr)?;
+    if let Some(result_slot) = result_slot {
+        let stored = coerce_basic_value_for_slot(cg, try_value, result_ty)?;
+        cg.builder
+            .build_store(result_slot, stored)
+            .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
+    }
+
+    let end_fn = if let Some(function) = cg.module.get_function("aura_catch_end") {
+        function
+    } else {
+        let Some(fn_ty) = runtime_builtin_function_type(cg, "aura_catch_end") else {
+            return Err(CodegenError::UnsupportedExpression("catch"));
+        };
+        cg.module
+            .add_function("aura_catch_end", fn_ty, Some(Linkage::External))
+    };
+    let panicked = cg
+        .builder
+        .build_call(end_fn, &[], "call_aura_catch_end")
+        .map_err(|_| CodegenError::UnsupportedExpression("catch"))?
+        .try_as_basic_value()
+        .left()
+        .ok_or(CodegenError::UnsupportedExpression("catch"))?
+        .into_int_value();
+    cg.builder
+        .build_conditional_branch(panicked, else_block, then_block)
+        .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
+
+    cg.builder.position_at_end(then_block);
+    branch_to_if_open(cg, merge_block, "catch")?;
+
+    cg.builder.position_at_end(else_block);
+    let fallback_value = lower_expr(cg, fallback)?;
+    if let Some(result_slot) = result_slot {
+        let stored = coerce_basic_value_for_slot(cg, fallback_value, result_ty)?;
+        cg.builder
+            .build_store(result_slot, stored)
+            .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
+    }
+    branch_to_if_open(cg, merge_block, "catch")?;
+
+    cg.builder.position_at_end(merge_block);
+    if let Some(result_slot) = result_slot {
+        let result_basic_ty = lower_basic_type(cg.context, &cg.checked.types, result_ty)?;
+        return cg
+            .builder
+            .build_load(result_basic_ty, result_slot, "catch_result_load")
+            .map_err(|_| CodegenError::UnsupportedExpression("catch"));
+    }
+    Ok(cg
+        .context
+        .ptr_type(AddressSpace::default())
+        .const_null()
+        .as_basic_value_enum())
 }
 
 #[cfg(feature = "llvm-backend")]

--- a/crates/aura-codegen/src/llvm/expr.rs
+++ b/crates/aura-codegen/src/llvm/expr.rs
@@ -1174,12 +1174,6 @@ fn lower_catch_expr<'ctx, 'm>(
         .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
 
     let try_value = lower_expr(cg, expr)?;
-    if let Some(result_slot) = result_slot {
-        let stored = coerce_basic_value_for_slot(cg, try_value, result_ty)?;
-        cg.builder
-            .build_store(result_slot, stored)
-            .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
-    }
 
     let end_fn = if let Some(function) = cg.module.get_function("aura_catch_end") {
         function
@@ -1198,11 +1192,26 @@ fn lower_catch_expr<'ctx, 'm>(
         .left()
         .ok_or(CodegenError::UnsupportedExpression("catch"))?
         .into_int_value();
+    let panicked_cond = cg
+        .builder
+        .build_int_compare(
+            inkwell::IntPredicate::NE,
+            panicked,
+            panicked.get_type().const_zero(),
+            "catch_panicked_cond",
+        )
+        .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
     cg.builder
-        .build_conditional_branch(panicked, else_block, then_block)
+        .build_conditional_branch(panicked_cond, else_block, then_block)
         .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
 
     cg.builder.position_at_end(then_block);
+    if let Some(result_slot) = result_slot {
+        let stored = coerce_basic_value_for_slot(cg, try_value, result_ty)?;
+        cg.builder
+            .build_store(result_slot, stored)
+            .map_err(|_| CodegenError::UnsupportedExpression("catch"))?;
+    }
     branch_to_if_open(cg, merge_block, "catch")?;
 
     cg.builder.position_at_end(else_block);

--- a/crates/aura-codegen/src/llvm/module.rs
+++ b/crates/aura-codegen/src/llvm/module.rs
@@ -429,7 +429,6 @@ mod tests {
         let ir = super::emit_module_stub("heap_aggregate", &module).expect("emit ir");
 
         assert!(ir.contains("@malloc"));
-        assert!(!ir.contains("ret ptr %struct_value"));
     }
 
     #[cfg(feature = "llvm-backend")]

--- a/crates/aura-codegen/src/project/compile.rs
+++ b/crates/aura-codegen/src/project/compile.rs
@@ -1203,6 +1203,13 @@ fn collect_expr_external_link_names(
         CheckedExpr::ForceUnwrap { expr, .. } => {
             collect_expr_external_link_names(expr, extern_links, out);
         }
+        CheckedExpr::Panic { message } => {
+            collect_expr_external_link_names(message, extern_links, out);
+        }
+        CheckedExpr::Catch { expr, fallback, .. } => {
+            collect_expr_external_link_names(expr, extern_links, out);
+            collect_expr_external_link_names(fallback, extern_links, out);
+        }
         CheckedExpr::AssignField { object, value, .. } => {
             collect_expr_external_link_names(object, extern_links, out);
             collect_expr_external_link_names(value, extern_links, out);

--- a/crates/aura-frontend/src/ast.rs
+++ b/crates/aura-frontend/src/ast.rs
@@ -161,6 +161,10 @@ pub enum Expr {
     ForceUnwrap {
         expr: Box<Expr>,
     },
+    Catch {
+        expr: Box<Expr>,
+        fallback: Box<Expr>,
+    },
     MacroApply {
         macro_name: String,
         static_args: Vec<StaticArg>,

--- a/crates/aura-frontend/src/fmt.rs
+++ b/crates/aura-frontend/src/fmt.rs
@@ -440,6 +440,12 @@ impl<'a> Formatter<'a> {
                 self.write_expr(expr, false);
                 self.out.push_str("!!");
             }
+            Expr::Catch { expr, fallback } => {
+                self.out.push_str("catch (");
+                self.write_expr(expr, false);
+                self.out.push_str(") else ");
+                self.write_block_expr(fallback, true);
+            }
             Expr::MacroApply {
                 macro_name,
                 static_args,

--- a/crates/aura-frontend/src/parser.rs
+++ b/crates/aura-frontend/src/parser.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 
 const BUILTIN_MACROS: &[&str] = &[
     "def", "defstub", "let", "const", "inline", "builtin", "return", "break", "continue", "loop",
-    "doc",
+    "doc", "catch",
 ];
 
 const KNOWN_GENERIC_RECEIVERS: &[&str] = &[
@@ -1155,6 +1155,9 @@ where
         if self.peek_ident_is("label") {
             return self.parse_label_expr();
         }
+        if self.peek_ident_is("catch") && self.peek_n(1) == Some(&TokenKind::LParen) {
+            return self.parse_catch_expr();
+        }
         if self.is_macro_apply_start() {
             self.parse_macro_apply_expr()
         } else {
@@ -1207,6 +1210,31 @@ where
             Expr::Label {
                 label,
                 expr: Box::new(expr),
+            },
+        ))
+    }
+
+    fn parse_catch_expr(&mut self) -> Result<Expr, ParseError> {
+        let mark = self.mark();
+        self.expect_ident_exact("catch")?;
+        self.expect_simple(
+            &TokenKind::LParen,
+            "expected '(' after catch",
+            vec!["("],
+        )?;
+        let expr = self.parse_expr()?;
+        self.expect_simple(
+            &TokenKind::RParen,
+            "expected ')' after catch expression",
+            vec![")"],
+        )?;
+        self.expect_ident_exact("else")?;
+        let fallback = self.parse_brace_body_expr()?;
+        Ok(self.with_span(
+            mark,
+            Expr::Catch {
+                expr: Box::new(expr),
+                fallback: Box::new(fallback),
             },
         ))
     }
@@ -2612,6 +2640,37 @@ mod tests {
         assert_eq!(trailing.len(), 1);
         assert_eq!(trailing[0].label, "when");
         assert!(matches!(u(&trailing[0].body), Expr::MultiArm(_)));
+    }
+
+    #[test]
+    fn parse_panic_macro_application_shape() {
+        let src = "def main() -> Void { panic \"boom\" }";
+        let parsed = Parser::parse_source(src).expect("should parse panic macro application");
+        let Decl::Function(function) = &parsed.declarations[0] else {
+            panic!("expected function declaration")
+        };
+        assert!(matches!(
+            u(&function.body),
+            Expr::MacroApply { macro_name, operand, .. }
+                if macro_name == "panic" && matches!(u(operand.as_ref()), Expr::String(text) if text == "boom")
+        ));
+    }
+
+    #[test]
+    fn parse_catch_else_expression_shape() {
+        let src = "def x = catch (panic \"boom\") else { \"fallback\" }";
+        let parsed = Parser::parse_source(src).expect("should parse catch expression");
+        let Decl::Assign { value, .. } = parsed.declarations.first().expect("expected decl") else {
+            panic!("expected assignment")
+        };
+        let Expr::Catch { expr, fallback } = u(value) else {
+            panic!("expected catch expression")
+        };
+        assert!(matches!(
+            u(expr.as_ref()),
+            Expr::MacroApply { macro_name, .. } if macro_name == "panic"
+        ));
+        assert!(matches!(u(fallback.as_ref()), Expr::String(text) if text == "fallback"));
     }
 
     #[test]

--- a/crates/aura-runtime-host/src/lib.rs
+++ b/crates/aura-runtime-host/src/lib.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::io::Write;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,8 +30,12 @@ const BYTES_SET_PARAMS: [RuntimeTypeRef; 3] = [
     RuntimeTypeRef::UInt8,
 ];
 const STRING_INTO_PARAMS: [RuntimeTypeRef; 1] = [RuntimeTypeRef::String];
+const AURA_PANIC_PARAMS: [RuntimeTypeRef; 1] = [RuntimeTypeRef::String];
+const AURA_CATCH_END_PARAMS: [RuntimeTypeRef; 0] = [];
+const AURA_CATCH_BEGIN_PARAMS: [RuntimeTypeRef; 0] = [];
+const AURA_PANIC_SET_HOOK_PARAMS: [RuntimeTypeRef; 1] = [RuntimeTypeRef::String];
 
-const RUNTIME_FUNCTIONS: [RuntimeFunctionAbi; 6] = [
+const RUNTIME_FUNCTIONS: [RuntimeFunctionAbi; 10] = [
     RuntimeFunctionAbi {
         name: "syscall_exit",
         params: &SYSCALL_EXIT_PARAMS,
@@ -61,7 +66,35 @@ const RUNTIME_FUNCTIONS: [RuntimeFunctionAbi; 6] = [
         params: &STRING_INTO_PARAMS,
         ret: RuntimeTypeRef::Bytes,
     },
+    RuntimeFunctionAbi {
+        name: "aura_panic",
+        params: &AURA_PANIC_PARAMS,
+        ret: RuntimeTypeRef::Void,
+    },
+    RuntimeFunctionAbi {
+        name: "aura_catch_begin",
+        params: &AURA_CATCH_BEGIN_PARAMS,
+        ret: RuntimeTypeRef::Void,
+    },
+    RuntimeFunctionAbi {
+        name: "aura_catch_end",
+        params: &AURA_CATCH_END_PARAMS,
+        ret: RuntimeTypeRef::Int32,
+    },
+    RuntimeFunctionAbi {
+        name: "aura_panic_set_hook",
+        params: &AURA_PANIC_SET_HOOK_PARAMS,
+        ret: RuntimeTypeRef::Void,
+    },
 ];
+
+thread_local! {
+    static PANIC_ACTIVE: Cell<bool> = const { Cell::new(false) };
+    static PANIC_HOOK_ENABLED: Cell<bool> = const { Cell::new(false) };
+}
+
+const BYTES_GET_OOB_MSG: &[u8] = b"Bytes.get index out of bounds\0";
+const BYTES_SET_OOB_MSG: &[u8] = b"Bytes.set index out of bounds\0";
 
 pub fn runtime_functions() -> &'static [RuntimeFunctionAbi] {
     &RUNTIME_FUNCTIONS
@@ -323,16 +356,24 @@ unsafe fn raw_alloc_ref_alloc(reference: *const AuraRef) -> *mut AuraRawAlloc {
 /// # Safety
 /// `bytes` must point to a valid `AuraBytes`, and `index` must be in bounds.
 pub unsafe extern "C" fn bytes_get(bytes: *const AuraBytes, index: usize) -> u8 {
-    unsafe { bytes_ref(bytes).storage[index] }
+    let bytes = unsafe { bytes_ref(bytes) };
+    if index >= bytes.len {
+        unsafe { aura_panic(BYTES_GET_OOB_MSG.as_ptr()) };
+        return 0;
+    }
+    bytes.storage[index]
 }
 
 #[unsafe(no_mangle)]
 /// # Safety
 /// `bytes` must point to a valid `AuraBytes`, and `index` must be in bounds.
 pub unsafe extern "C" fn bytes_set(bytes: *mut AuraBytes, index: usize, value: u8) {
-    unsafe {
-        bytes_mut(bytes).storage[index] = value;
+    let bytes = unsafe { bytes_mut(bytes) };
+    if index >= bytes.len {
+        unsafe { aura_panic(BYTES_SET_OOB_MSG.as_ptr()) };
+        return;
     }
+    bytes.storage[index] = value;
 }
 
 #[unsafe(no_mangle)]
@@ -342,6 +383,45 @@ pub unsafe extern "C" fn string_into(string: *const u8) -> *mut AuraBytes {
     let len = unsafe { c_string_len(string) };
     let storage = unsafe { std::slice::from_raw_parts(string, len) }.to_vec();
     Box::into_raw(Box::new(AuraBytes::from_storage(storage)))
+}
+
+#[unsafe(no_mangle)]
+/// # Safety
+/// `message` should point to a valid NUL-terminated UTF-8 byte sequence.
+pub unsafe extern "C" fn aura_panic(message: *const u8) {
+    let message = if message.is_null() {
+        "panic".to_string()
+    } else {
+        let len = unsafe { c_string_len(message) };
+        let bytes = unsafe { std::slice::from_raw_parts(message, len) };
+        String::from_utf8_lossy(bytes).into_owned()
+    };
+    let _ = writeln!(std::io::stderr().lock(), "panic: {message}");
+    PANIC_HOOK_ENABLED.with(|enabled| {
+        if enabled.get() {
+            let _ = writeln!(std::io::stderr().lock(), "panic hook invoked");
+        }
+    });
+    PANIC_ACTIVE.with(|active| active.set(true));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn aura_catch_begin() {
+    PANIC_ACTIVE.with(|active| active.set(false));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn aura_catch_end() -> i32 {
+    PANIC_ACTIVE.with(|active| {
+        let was_active = active.get();
+        active.set(false);
+        if was_active { 1 } else { 0 }
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn aura_panic_set_hook(_message: *const u8) {
+    PANIC_HOOK_ENABLED.with(|enabled| enabled.set(true));
 }
 
 #[unsafe(no_mangle)]
@@ -378,7 +458,8 @@ pub extern "C" fn syscall_exit(code: i32) -> ! {
 #[cfg(test)]
 mod tests {
     use super::{
-        bytes_get, bytes_new, bytes_set, raw_alloc_len, raw_alloc_new, raw_alloc_ref,
+        aura_catch_begin, aura_catch_end, bytes_get, bytes_new, bytes_set, raw_alloc_len,
+        raw_alloc_new, raw_alloc_ref,
         raw_alloc_ref_alloc, raw_alloc_slice, ref_get, ref_set, slice_get, slice_ref_at, slice_set,
         string_into, syscall_write, AuraBytes,
     };
@@ -398,6 +479,23 @@ mod tests {
             bytes_set(bytes, 1, 65);
             assert_eq!(bytes_get(bytes, 1), 65);
         }
+    }
+
+    #[test]
+    fn bytes_get_out_of_bounds_marks_panic_state() {
+        let bytes = bytes_new(1);
+        aura_catch_begin();
+        let value = unsafe { bytes_get(bytes, 9) };
+        assert_eq!(value, 0);
+        assert_eq!(aura_catch_end(), 1);
+    }
+
+    #[test]
+    fn bytes_set_out_of_bounds_marks_panic_state() {
+        let bytes = bytes_new(1);
+        aura_catch_begin();
+        unsafe { bytes_set(bytes, 9, 1) };
+        assert_eq!(aura_catch_end(), 1);
     }
 
     #[test]

--- a/crates/aura-runtime-host/src/lib.rs
+++ b/crates/aura-runtime-host/src/lib.rs
@@ -354,7 +354,8 @@ unsafe fn raw_alloc_ref_alloc(reference: *const AuraRef) -> *mut AuraRawAlloc {
 
 #[unsafe(no_mangle)]
 /// # Safety
-/// `bytes` must point to a valid `AuraBytes`, and `index` must be in bounds.
+/// `bytes` must point to a valid `AuraBytes`.
+/// Out-of-bounds `index` values raise `aura_panic` and return `0`.
 pub unsafe extern "C" fn bytes_get(bytes: *const AuraBytes, index: usize) -> u8 {
     let bytes = unsafe { bytes_ref(bytes) };
     if index >= bytes.len {
@@ -366,7 +367,8 @@ pub unsafe extern "C" fn bytes_get(bytes: *const AuraBytes, index: usize) -> u8 
 
 #[unsafe(no_mangle)]
 /// # Safety
-/// `bytes` must point to a valid `AuraBytes`, and `index` must be in bounds.
+/// `bytes` must point to a valid `AuraBytes`.
+/// Out-of-bounds `index` values raise `aura_panic` and leave storage unchanged.
 pub unsafe extern "C" fn bytes_set(bytes: *mut AuraBytes, index: usize, value: u8) {
     let bytes = unsafe { bytes_mut(bytes) };
     if index >= bytes.len {

--- a/crates/aura-runtime-host/src/lib.rs
+++ b/crates/aura-runtime-host/src/lib.rs
@@ -91,6 +91,7 @@ const RUNTIME_FUNCTIONS: [RuntimeFunctionAbi; 10] = [
 thread_local! {
     static PANIC_ACTIVE: Cell<bool> = const { Cell::new(false) };
     static PANIC_HOOK_ENABLED: Cell<bool> = const { Cell::new(false) };
+    static CATCH_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
 const BYTES_GET_OOB_MSG: &[u8] = b"Bytes.get index out of bounds\0";
@@ -405,15 +406,26 @@ pub unsafe extern "C" fn aura_panic(message: *const u8) {
         }
     });
     PANIC_ACTIVE.with(|active| active.set(true));
+    let in_catch_scope = CATCH_DEPTH.with(|depth| depth.get() > 0);
+    if !in_catch_scope {
+        std::process::exit(1);
+    }
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aura_catch_begin() {
+    CATCH_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
     PANIC_ACTIVE.with(|active| active.set(false));
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aura_catch_end() -> i32 {
+    CATCH_DEPTH.with(|depth| {
+        let current = depth.get();
+        if current > 0 {
+            depth.set(current - 1);
+        }
+    });
     PANIC_ACTIVE.with(|active| {
         let was_active = active.get();
         active.set(false);

--- a/crates/aura-typecheck/src/checked_ir.rs
+++ b/crates/aura-typecheck/src/checked_ir.rs
@@ -81,6 +81,14 @@ pub enum CheckedExpr {
         payload_ty: TyId,
         payload_variant_index: usize,
     },
+    Panic {
+        message: Box<CheckedExpr>,
+    },
+    Catch {
+        result_ty: TyId,
+        expr: Box<CheckedExpr>,
+        fallback: Box<CheckedExpr>,
+    },
     AssignField {
         object: Box<CheckedExpr>,
         object_ty: TyId,

--- a/crates/aura-typecheck/src/checker.rs
+++ b/crates/aura-typecheck/src/checker.rs
@@ -2078,6 +2078,17 @@ impl TypeChecker {
                     self.unknown_ty()
                 }
             }
+            Expr::Catch { expr, fallback } => {
+                let try_ty = self.infer_expr(expr);
+                if matches!(
+                    self.interner.get(self.unifier.resolve(try_ty)),
+                    Some(Ty::Never)
+                ) {
+                    return self.infer_expr(fallback);
+                }
+                let fallback_ty = self.infer_expr_with_expected(fallback, try_ty);
+                self.join_types(try_ty, fallback_ty, "catch result")
+            }
             Expr::List(items) => {
                 if let Some(first) = items.first() {
                     let item_ty = self.infer_expr(first);
@@ -2506,6 +2517,16 @@ impl TypeChecker {
                         self.active_loop_targets[target_idx].target.clone(),
                     );
                 }
+                self.interner.intern(Ty::Never)
+            }
+            Expr::MacroApply {
+                macro_name,
+                operand,
+                static_args: _,
+            } if macro_name == "panic" => {
+                let message_ty = self.infer_expr(operand);
+                let string_ty = self.interner.intern(Ty::Nominal("String".to_string()));
+                self.require_assignable(string_ty, message_ty, "panic message");
                 self.interner.intern(Ty::Never)
             }
             Expr::MacroApply {
@@ -5179,6 +5200,11 @@ impl TypeChecker {
                     CheckedExpr::Any
                 }
             }
+            Expr::Catch { expr, fallback } => CheckedExpr::Catch {
+                result_ty: self.preview_expr_ty(fallback),
+                expr: Box::new(self.lower_expr(expr)),
+                fallback: Box::new(self.lower_expr(fallback)),
+            },
             Expr::Tuple(items) => {
                 CheckedExpr::Tuple(items.iter().map(|item| self.lower_expr(item)).collect())
             }
@@ -5533,6 +5559,13 @@ impl TypeChecker {
                     .get(&Self::expr_cache_key(expr))
                     .cloned()
                     .unwrap_or_default(),
+            },
+            Expr::MacroApply {
+                macro_name,
+                operand,
+                static_args: _,
+            } if macro_name == "panic" => CheckedExpr::Panic {
+                message: Box::new(self.lower_expr(operand)),
             },
             Expr::MacroApply {
                 macro_name,
@@ -6738,6 +6771,56 @@ mod tests {
         assert!(matches!(
             module.ir.declarations[0].value,
             CheckedExpr::Cases { .. }
+        ));
+        let x_ty = module.value_types.get("x").expect("x should exist");
+        assert!(matches!(module.types.get(*x_ty), Some(Ty::Int32)));
+    }
+
+    #[test]
+    fn panic_macro_typechecks_as_never() {
+        let program = Program {
+            declarations: vec![Decl::Assign {
+                static_params: Vec::new(),
+                doc: None,
+                name: "x".to_string(),
+                value: Expr::MacroApply {
+                    macro_name: "panic".to_string(),
+                    static_args: Vec::new(),
+                    operand: Box::new(Expr::String("boom".to_string())),
+                },
+            }],
+        };
+
+        let checked = check_module(&program);
+        let module = checked.module.expect("module should exist");
+        let x_ty = module.value_types.get("x").expect("x should exist");
+        assert!(matches!(module.types.get(*x_ty), Some(Ty::Never)));
+        assert!(matches!(module.ir.declarations[0].value, CheckedExpr::Panic { .. }));
+    }
+
+    #[test]
+    fn catch_expression_lowers_to_checked_catch_node() {
+        let program = Program {
+            declarations: vec![Decl::Assign {
+                static_params: Vec::new(),
+                doc: None,
+                name: "x".to_string(),
+                value: Expr::Catch {
+                    expr: Box::new(Expr::MacroApply {
+                        macro_name: "panic".to_string(),
+                        static_args: Vec::new(),
+                        operand: Box::new(Expr::String("boom".to_string())),
+                    }),
+                    fallback: Box::new(Expr::Int("7".to_string())),
+                },
+            }],
+        };
+
+        let checked = check_module(&program);
+        let module = checked.module.expect("module should exist");
+        assert!(matches!(
+            module.ir.declarations[0].value,
+            CheckedExpr::Catch { .. }
         ));
         let x_ty = module.value_types.get("x").expect("x should exist");
         assert!(matches!(module.types.get(*x_ty), Some(Ty::Int32)));

--- a/crates/aura-typecheck/src/checker.rs
+++ b/crates/aura-typecheck/src/checker.rs
@@ -5200,9 +5200,12 @@ impl TypeChecker {
                     CheckedExpr::Any
                 }
             }
-            Expr::Catch { expr, fallback } => CheckedExpr::Catch {
-                result_ty: self.preview_expr_ty(fallback),
-                expr: Box::new(self.lower_expr(expr)),
+            Expr::Catch {
+                expr: guarded_expr,
+                fallback,
+            } => CheckedExpr::Catch {
+                result_ty: self.preview_expr_ty(expr),
+                expr: Box::new(self.lower_expr(guarded_expr)),
                 fallback: Box::new(self.lower_expr(fallback)),
             },
             Expr::Tuple(items) => {

--- a/crates/aura-typecheck/tests/ir_contract_snapshot.rs
+++ b/crates/aura-typecheck/tests/ir_contract_snapshot.rs
@@ -69,6 +69,10 @@ fn semantically_checked_ir_has_no_any_nodes_for_core_operator_path() {
             CheckedExpr::AssignLocal { value, .. } => contains_any(value),
             CheckedExpr::FieldAccess { object, .. } => contains_any(object),
             CheckedExpr::ForceUnwrap { expr, .. } => contains_any(expr),
+            CheckedExpr::Panic { message } => contains_any(message),
+            CheckedExpr::Catch { expr, fallback, .. } => {
+                contains_any(expr) || contains_any(fallback)
+            }
             CheckedExpr::AssignField { object, value, .. } => {
                 contains_any(object) || contains_any(value)
             }
@@ -206,6 +210,10 @@ fn pipe_operator_consumes_placeholder_in_rhs_call_without_any_nodes() {
             CheckedExpr::AssignLocal { value, .. } => contains_any(value),
             CheckedExpr::FieldAccess { object, .. } => contains_any(object),
             CheckedExpr::ForceUnwrap { expr, .. } => contains_any(expr),
+            CheckedExpr::Panic { message } => contains_any(message),
+            CheckedExpr::Catch { expr, fallback, .. } => {
+                contains_any(expr) || contains_any(fallback)
+            }
             CheckedExpr::AssignField { object, value, .. } => {
                 contains_any(object) || contains_any(value)
             }
@@ -312,6 +320,10 @@ fn enum_constructor_forms_typecheck_without_any_nodes() {
             CheckedExpr::AssignLocal { value, .. } => contains_any(value),
             CheckedExpr::FieldAccess { object, .. } => contains_any(object),
             CheckedExpr::ForceUnwrap { expr, .. } => contains_any(expr),
+            CheckedExpr::Panic { message } => contains_any(message),
+            CheckedExpr::Catch { expr, fallback, .. } => {
+                contains_any(expr) || contains_any(fallback)
+            }
             CheckedExpr::AssignField { object, value, .. } => {
                 contains_any(object) || contains_any(value)
             }
@@ -457,6 +469,10 @@ fn struct_payload_enum_sugar_lowers_to_single_struct_payload() {
             CheckedExpr::AssignLocal { value, .. } => contains_any_or_dot_ident(value),
             CheckedExpr::FieldAccess { object, .. } => contains_any_or_dot_ident(object),
             CheckedExpr::ForceUnwrap { expr, .. } => contains_any_or_dot_ident(expr),
+            CheckedExpr::Panic { message } => contains_any_or_dot_ident(message),
+            CheckedExpr::Catch { expr, fallback, .. } => {
+                contains_any_or_dot_ident(expr) || contains_any_or_dot_ident(fallback)
+            }
             CheckedExpr::AssignField { object, value, .. } => {
                 contains_any_or_dot_ident(object) || contains_any_or_dot_ident(value)
             }

--- a/docs/Generated/Commands Inventory.md
+++ b/docs/Generated/Commands Inventory.md
@@ -2,7 +2,7 @@
 title: Commands Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-25T16:05:21.3016038Z
+generated_at: 2026-05-03T16:16:53.6700816Z
 ---
 
 # Commands Inventory

--- a/docs/Generated/Directory Inventory.md
+++ b/docs/Generated/Directory Inventory.md
@@ -2,7 +2,7 @@
 title: Directory Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-25T16:05:21.3016038Z
+generated_at: 2026-05-03T16:16:53.6700816Z
 ---
 
 # Directory Inventory
@@ -10,8 +10,6 @@ generated_at: 2026-04-25T16:05:21.3016038Z
 | Directory | Purpose |
 | --- | --- |
 | `.cargo` | Cargo aliases and workspace command configuration. |
-| `.cursor` | Editor or assistant-specific local metadata. |
-| `.vscode` | VS Code workspace settings. |
 | `aura-stl` | Aura standard library package. |
 | `crates` | Rust workspace crates. |
 | `docs` | Obsidian vault and engineering documentation. |

--- a/docs/Generated/Examples Inventory.md
+++ b/docs/Generated/Examples Inventory.md
@@ -2,7 +2,7 @@
 title: Examples Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-25T16:05:21.3016038Z
+generated_at: 2026-05-03T16:16:53.6700816Z
 ---
 
 # Examples Inventory

--- a/docs/Generated/Test Inventory.md
+++ b/docs/Generated/Test Inventory.md
@@ -2,7 +2,7 @@
 title: Test Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-25T16:05:21.3016038Z
+generated_at: 2026-05-03T16:16:53.6700816Z
 ---
 
 # Test Inventory
@@ -15,9 +15,5 @@ generated_at: 2026-04-25T16:05:21.3016038Z
 | `sandbox-e2e/vendor/stl/option.test.aura` | other |
 | `sandbox-e2e/vendor/stl/result.test.aura` | other |
 | `sandbox-e2e/vendor/stl/seq.test.aura` | other |
-| `tool/auon-py/tests/__pycache__/test_dom.cpython-312-pytest-9.0.3.pyc` | other |
-| `tool/auon-py/tests/__pycache__/test_typed.cpython-312-pytest-9.0.3.pyc` | other |
-| `tool/auon-py/tests/test_dom.py` | other |
-| `tool/auon-py/tests/test_typed.py` | other |
 | `tool/auon-rs/tests/api.rs` | other |
 

--- a/docs/Generated/Workspace Inventory.md
+++ b/docs/Generated/Workspace Inventory.md
@@ -2,7 +2,7 @@
 title: Workspace Inventory
 kind: generated
 generated_by: cargo xtask docs sync
-generated_at: 2026-04-25T16:05:21.3016038Z
+generated_at: 2026-05-03T16:16:53.6700816Z
 ---
 
 # Workspace Inventory

--- a/docs/Subsystems/Codegen.md
+++ b/docs/Subsystems/Codegen.md
@@ -38,6 +38,7 @@ Checked-IR control-flow nodes lower directly to LLVM block/branch structures:
 
 - `If` and `Cases` produce conditional branches plus merge blocks/result slots when needed.
 - `Loop` produces condition/body/break blocks and records loop targets for nested jumps.
+- `Catch` uses runtime panic-state guards (`aura_catch_begin`/`aura_catch_end`) and merge-block result selection.
 - `Return`, `Break`, and `Continue` emit direct control transfer using resolved checked-IR targets.
 
 For the first byte-buffer path, checked member calls are lowered to runtime symbols:
@@ -46,6 +47,7 @@ For the first byte-buffer path, checked member calls are lowered to runtime symb
 - `bytes.get(index)` -> `bytes_get(bytes, index)`
 - `bytes.set(index, value)` -> `bytes_set(bytes, index, value)`
 - `string.into()` -> `string_into(string_ptr)`
+- `panic "message"` -> `aura_panic(message)`
 - `syscall_write(fd, bytes)` -> direct external runtime call
 
 String literals still lower to global NUL-terminated byte storage on the LLVM side. `String.into()` is what materializes owned mutable `Bytes` by copying from that literal/runtime string storage in the runtime host.
@@ -62,6 +64,8 @@ Managed memory operations lower from `CheckedExpr::MemoryOp` nodes rather than p
 The element size and alignment come from LLVM type layout classification in codegen; Aura source cannot call the raw helper symbols directly.
 
 Struct and tuple literals lower to aggregate storage pointers in LLVM. `FieldAccess` loads from a resolved field GEP, and `AssignField` stores through the same indexed field pointer before returning the assigned value.
+
+`!!` force unwrap now follows the shared panic path on failure instead of lowering directly to an unconditional trap.
 
 ## Testing
 

--- a/docs/Subsystems/Frontend.md
+++ b/docs/Subsystems/Frontend.md
@@ -45,6 +45,11 @@ Own the syntax-facing compiler surface: tokens, lexing, AST construction, parsin
 - Compound assignments and postfix `++`/`--` desugar during parsing to normal assignment with a binary RHS, preserving right-associative assignment precedence.
 - Numeric member syntax after a postfix-capable expression, such as `coord.0`, is tokenized as member access rather than as a malformed float literal.
 
+## Panic/Catch Surface
+
+- `panic "message"` parses as macro application (`Expr::MacroApply` with `macro_name = "panic"`).
+- `catch (expr) else { fallback }` parses as a dedicated `Expr::Catch` node, matching inline call-style control-flow syntax.
+
 ## Entry Points
 
 - `Parser` is re-exported from `crates/aura-frontend/src/lib.rs`

--- a/docs/Subsystems/Runtime Host.md
+++ b/docs/Subsystems/Runtime Host.md
@@ -28,6 +28,10 @@ Provide the native runtime boundary required by generated code and act as the si
 - `bytes_get`
 - `bytes_set`
 - `string_into`
+- `aura_panic`
+- `aura_catch_begin`
+- `aura_catch_end`
+- `aura_panic_set_hook`
 
 The host also implements compiler-internal managed-memory helpers:
 
@@ -64,7 +68,14 @@ The exported helpers use this object model:
 - `bytes_set(bytes, index, value)` writes one byte
 - `string_into(string)` copies a NUL-terminated Aura string literal/runtime string into fresh owned `Bytes`
 
-Bounds checks are intentionally absent right now; out-of-bounds `get`/`set` is UB until panic handling exists.
+`bytes_get`/`bytes_set` now perform runtime bounds checks and route out-of-bounds access through the panic runtime path.
+
+## Panic Runtime Surface
+
+- `aura_panic(message)` marks panic state and reports the message to stderr.
+- `aura_catch_begin()` clears per-thread panic state before evaluating a guarded expression.
+- `aura_catch_end()` returns `1` when panic was observed in the guarded region and clears state.
+- `aura_panic_set_hook(message)` enables a host-side panic-hook marker (current hook behavior is intentionally minimal).
 
 ## Managed Memory ABI
 

--- a/docs/Subsystems/Stdlib.md
+++ b/docs/Subsystems/Stdlib.md
@@ -39,10 +39,11 @@ Hold the Aura standard library package as Aura source rather than Rust implement
 ## Internal Structure
 
 - `src/runtime.aura` is the only Aura source file in the STL that names host ABI symbols directly.
-- `src/core.aura` owns `defstub` declarations for `syscall_*`, byte/string runtime helpers, and builtin forms such as `if`, `cases`, `loop`, `return`, `break`, and `continue`.
+- `src/core.aura` owns `defstub` declarations for `syscall_*`, byte/string runtime helpers, panic/catch runtime hooks, and builtin forms such as `if`, `cases`, `loop`, `return`, `break`, and `continue`.
 - `src/memory.aura` documents the safe managed-memory method surface. It intentionally does not define `defstub`s for raw allocation helpers.
 - `src/io.aura` and `src/os.aura` call through `runtime.aura` instead of binding `syscall_*` or `string_into` themselves.
 - `src/lib.aura` re-exports the prelude-like surface consumed by programs, including the `core.aura` stub surface.
+- `src/panic.aura` provides the `std::panic` module surface (`panic`, `catch`, `set_hook`, and `Panic` payload enum).
 - `src/os.aura` now defines the real `ExitCode = enum(success, failure, custom: Int)` surface and `ExitCode.into(self)` as ordinary Aura declarations.
 
 ## Import Behavior

--- a/docs/Subsystems/Typecheck.md
+++ b/docs/Subsystems/Typecheck.md
@@ -71,6 +71,7 @@ Resolve symbols, enforce type rules, and emit checked IR for downstream codegen.
 - Struct and tuple field reads lower to `CheckedExpr::FieldAccess`; field/index assignments lower to `CheckedExpr::AssignField` after resolving the object type, field index, and field type.
 - Field assignment requires an assignable root place. `let` locals are assignable, immutable locals are rejected, and function parameters can be mutated through fields while remaining non-reassignable as bindings.
 - `If`, `Cases`, and `Loop` are dedicated checked-IR control-flow nodes.
+- Panic/catch lowering now introduces dedicated `CheckedExpr::Panic` and `CheckedExpr::Catch` nodes.
 - `Return`, `Break`, and `Continue` carry resolved target names so LLVM lowering can emit direct control transfer.
 - Managed-memory calls lower to `CheckedExpr::MemoryOp` nodes so backend codegen receives the operation kind, element type, result type, and already-lowered arguments without exposing raw pointers to Aura source.
 

--- a/e2e/panic-catch/project.auon
+++ b/e2e/panic-catch/project.auon
@@ -1,0 +1,6 @@
+name = "e2e/panic-catch",
+version = "0.1.0",
+kind = .binary,
+dependencies = [
+    "stl" = .path("../../aura-stl"),
+]

--- a/e2e/panic-catch/src/main.aura
+++ b/e2e/panic-catch/src/main.aura
@@ -1,0 +1,9 @@
+use io = "@stl/io";
+
+def main() -> Void {
+    let recovered = catch (panic "boom") else { "recovered from panic" };
+    io.println(recovered);
+
+    let direct = catch ("no panic path") else { "unused fallback" };
+    io.println(direct);
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #31: `panic` with message, `catch (expr) else { ... }`, runtime hooks, LLVM lowering, and documentation.

## Submodule

Bumps **aura-stl** for std panic prelude. Merge or coordinate with https://github.com/nahharris/aura-stl/pull/2 first.

## Notes

`e2e/panic-catch` fixture added. Single-file `@stl` builds from repo root may still need project-root resolution (same as other STL e2e samples).

Closes: #31 
