### PR TITLE
feat: Any as empty interface (stdlib + compiler)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -195,7 +195,6 @@ This representation is used by builtin stubs so labeled trailing closure forms c
 
 Examples of built-in / standard types:
 
-
 | Type expression           | Meaning                                                              |
 | ------------------------- | -------------------------------------------------------------------- |
 | `Int`                     | 64-bit signed integer                                                |
@@ -212,9 +211,8 @@ Examples of built-in / standard types:
 | `Option[T]`               | `enum(null, some: T)` — nullable value                               |
 | `Result[T, E]`            | `enum(err: E, ok: T)` — fallible value                               |
 | `Iterable[T]`             | Any type that can be iterated                                        |
-| `Any`                     | Shorthand for `interface()` — accepts any value                      |
+| `Any`                     | Defined in `aura-stl` as `def Any = interface();` — the empty interface; accepts any value. The compiler also pre-registers this name like `Int`/`Float` so single-file programs resolve `Any` without importing the stdlib. |
 | `Never`                   | Bottom type — `Never` is assignable to every other type              |
-
 
 ### Tuples
 
@@ -366,7 +364,7 @@ def any_print(msg: interface(to_string: Func[(), String])) -> Void { ... }
 def ToStr = interface(to_string: Func[(), String])
 ```
 
-The compiler models `interface(...)` as a first-class type node through frontend AST and typecheck IR (not as a nominal fallback), preserving each declared member signature. Interface constraints are checked structurally against the receiver method set, including named aliases and anonymous `interface(...)` constraints. The empty interface `interface()` is equivalent to the builtin `Any` type and accepts any value. On the other hand, the `Never` type would be equivalent to an interface with all the imaginable methods, making it impossible to satisfy, yet castable to any other type.
+The compiler models `interface(...)` as a first-class type node through frontend AST and typecheck IR (not as a nominal fallback), preserving each declared member signature. Interface constraints are checked structurally against the receiver method set, including named aliases and anonymous `interface(...)` constraints. The empty interface `interface()` is the type named `Any` in the standard library (`aura-stl/src/any.aura`); it accepts any value. On the other hand, the `Never` type would be equivalent to an interface with all the imaginable methods, making it impossible to satisfy, yet castable to any other type.
 
 For runtime behavior, interface-typed values are lowered as interface objects (data pointer + witness/vtable pointer). Calls on interface-typed receivers lower through dynamic dispatch slots, while calls on concrete receiver types keep the direct static-call path.
 

--- a/crates/aura-codegen/src/llvm/types.rs
+++ b/crates/aura-codegen/src/llvm/types.rs
@@ -40,7 +40,7 @@ pub fn classify_type(types: &TyInterner, ty_id: TyId) -> Result<AuraValueType, C
         Ty::Void => Ok(AuraValueType::Void),
         Ty::Enum(_) => Ok(AuraValueType::Aggregate(ty_id)),
         Ty::Never
-        | Ty::Any
+        | Ty::Interface(_)
         | Ty::Nominal(_)
         | Ty::RawAlloc(_)
         | Ty::Slice(_)
@@ -54,7 +54,6 @@ pub fn classify_type(types: &TyInterner, ty_id: TyId) -> Result<AuraValueType, C
         | Ty::Tuple(_)
         | Ty::Struct(_)
         | Ty::Union(_)
-        | Ty::Interface(_)
         | Ty::InterfaceObject(_)
         | Ty::GenericParam(_)
         | Ty::InferVar(_) => Ok(AuraValueType::Pointer),
@@ -364,7 +363,6 @@ mod llvm_lowering {
             | Ty::Union(_)
             | Ty::GenericParam(_)
             | Ty::InferVar(_)
-            | Ty::Any
             | Ty::Interface(_)
             | Ty::InterfaceObject(_) => true,
         })

--- a/crates/aura-codegen/src/project/compile.rs
+++ b/crates/aura-codegen/src/project/compile.rs
@@ -954,7 +954,6 @@ fn ty_to_type_ref(types: &TyInterner, ty_id: aura_typecheck::TyId) -> TypeRef {
         Some(Ty::Char) => TypeRef::Primitive(PrimitiveType::Char),
         Some(Ty::Void) => TypeRef::Primitive(PrimitiveType::Void),
         Some(Ty::Never) => TypeRef::Primitive(PrimitiveType::Never),
-        Some(Ty::Any) => TypeRef::Primitive(PrimitiveType::Any),
         Some(Ty::Nominal(name)) => TypeRef::Nominal(name.clone()),
         Some(Ty::RawAlloc(item)) => TypeRef::RawAlloc(Box::new(ty_to_type_ref(types, *item))),
         Some(Ty::Slice(item)) => TypeRef::Slice(Box::new(ty_to_type_ref(types, *item))),
@@ -1047,8 +1046,14 @@ fn ty_ref_to_ty_id(types: &mut TyInterner, ty: &TypeRef) -> aura_typecheck::TyId
             PrimitiveType::Char => types.intern(Ty::Char),
             PrimitiveType::Void => types.intern(Ty::Void),
             PrimitiveType::Never => types.intern(Ty::Never),
-            PrimitiveType::Any => types.intern(Ty::Any),
         },
+        TypeRef::Interface(members) => {
+            let fields = members
+                .iter()
+                .map(|(name, ty)| (name.clone(), ty_ref_to_ty_id(types, ty)))
+                .collect::<Vec<_>>();
+            types.intern(Ty::Interface(fields))
+        }
         TypeRef::InferVar(v) => types.intern(Ty::InferVar(*v)),
         TypeRef::GenericParam(name) => types.intern(Ty::GenericParam(name.clone())),
         TypeRef::Nominal(name) => types.intern(Ty::Nominal(name.clone())),
@@ -1128,13 +1133,6 @@ fn ty_ref_to_ty_id(types: &mut TyInterner, ty: &TypeRef) -> aura_typecheck::TyId
                 .collect::<Vec<_>>();
             types.intern(Ty::Union(items))
         }
-        TypeRef::Interface(members) => {
-            let members = members
-                .iter()
-                .map(|(name, ty)| (name.clone(), ty_ref_to_ty_id(types, ty)))
-                .collect::<Vec<_>>();
-            types.intern(Ty::Interface(members))
-        }
         TypeRef::Enum(variants) => {
             let variants = variants
                 .iter()
@@ -1147,7 +1145,7 @@ fn ty_ref_to_ty_id(types: &mut TyInterner, ty: &TypeRef) -> aura_typecheck::TyId
                 .collect::<Vec<_>>();
             types.intern(Ty::Enum(variants))
         }
-        TypeRef::Unknown => types.intern(Ty::Any),
+        TypeRef::Unknown => types.intern(Ty::Interface(Vec::new())),
     }
 }
 

--- a/crates/aura-diagnostics/src/issue.rs
+++ b/crates/aura-diagnostics/src/issue.rs
@@ -54,6 +54,9 @@ pub enum Issue {
     InterfaceMethodMismatch {
         detail: String,
     },
+    InterfaceDuplicateMember {
+        name: String,
+    },
     MacroUntyped,
     MainSignature,
     OpNonNumeric,
@@ -120,6 +123,7 @@ impl Issue {
             Self::InterfaceBoundUnsatisfied { .. } => "E_INTERFACE_BOUND_UNSAT",
             Self::InterfaceMethodMissing { .. } => "E_INTERFACE_METHOD_MISSING",
             Self::InterfaceMethodMismatch { .. } => "E_INTERFACE_METHOD_MISMATCH",
+            Self::InterfaceDuplicateMember { .. } => "E_INTERFACE_DUP_MEMBER",
             Self::MacroUntyped => "E_MACRO_UNTYPED",
             Self::MainSignature => "E_MAIN_SIGNATURE",
             Self::OpNonNumeric => "E_OP_NON_NUMERIC",
@@ -196,6 +200,9 @@ impl Issue {
             Self::InterfaceBoundUnsatisfied { detail } => detail.clone(),
             Self::InterfaceMethodMissing { detail } => detail.clone(),
             Self::InterfaceMethodMismatch { detail } => detail.clone(),
+            Self::InterfaceDuplicateMember { name } => {
+                format!("duplicate interface member `{name}`")
+            }
             Self::MacroUntyped => "macro value used where typed value is required".to_string(),
             Self::MainSignature => "invalid main signature".to_string(),
             Self::OpNonNumeric => "numeric operator requires numeric operands".to_string(),

--- a/crates/aura-diagnostics/src/type_ref.rs
+++ b/crates/aura-diagnostics/src/type_ref.rs
@@ -20,7 +20,6 @@ pub enum PrimitiveType {
     Char,
     Void,
     Never,
-    Any,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -87,7 +86,6 @@ impl fmt::Display for PrimitiveType {
             Self::Char => "Char",
             Self::Void => "Void",
             Self::Never => "Never",
-            Self::Any => "Any",
         };
         f.write_str(name)
     }
@@ -144,14 +142,6 @@ impl fmt::Display for TypeRef {
                     .join(" | ");
                 write!(f, "union({joined})")
             }
-            Self::Interface(members) => {
-                let joined = members
-                    .iter()
-                    .map(|(name, ty)| format!("{name}: {ty}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                write!(f, "interface({joined})")
-            }
             Self::Enum(variants) => {
                 let joined = variants
                     .iter()
@@ -162,6 +152,17 @@ impl fmt::Display for TypeRef {
                     .collect::<Vec<_>>()
                     .join(", ");
                 write!(f, "enum({joined})")
+            }
+            Self::Interface(members) => {
+                if members.is_empty() {
+                    return f.write_str("Any");
+                }
+                let joined = members
+                    .iter()
+                    .map(|(name, ty)| format!("{name}: {ty}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "interface({joined})")
             }
             Self::Unknown => f.write_str("<unknown>"),
             Self::RawAlloc(item) => write!(f, "RawAlloc[{item}]"),
@@ -237,5 +238,11 @@ mod tests {
         };
 
         assert_eq!(ty.to_string(), "(as value: Int32) -> Void");
+    }
+
+    #[test]
+    fn empty_interface_displays_as_any() {
+        let ty = TypeRef::Interface(Vec::new());
+        assert_eq!(ty.to_string(), "Any");
     }
 }

--- a/crates/aura-frontend/src/ast.rs
+++ b/crates/aura-frontend/src/ast.rs
@@ -95,6 +95,7 @@ pub struct Param {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeExpr {
     Named { name: String, args: Vec<StaticArg> },
+    /// `interface(name: T, ...)` — empty `interface()` is the top type (see stdlib `Any`).
     Interface(Vec<(String, TypeExpr)>),
     Tuple(Vec<TypeExpr>),
     Struct(Vec<(String, TypeExpr)>),

--- a/crates/aura-frontend/src/parser.rs
+++ b/crates/aura-frontend/src/parser.rs
@@ -716,7 +716,7 @@ where
             return Ok(TypeExpr::Static(Box::new(inner)));
         }
 
-        if self.peek_ident_is("interface") {
+        if self.peek_ident_is("interface") && matches!(self.peek_n(1), Some(TokenKind::LParen)) {
             self.bump();
             return self.parse_interface_type_expr();
         }
@@ -3367,6 +3367,20 @@ mod tests {
         let src = "def Broken = interface(read Func[(), String])";
         let err = Parser::parse_source(src).expect_err("interface member syntax should require ':'");
         assert!(err.message.contains("expected"));
+    }
+
+    #[test]
+    fn parse_interface_identifier_is_named_type_not_keyword() {
+        let src = "def alias = interface;";
+        let parsed = Parser::parse_source(src).expect("parse type named `interface`");
+        let value = match &parsed.declarations[0] {
+            Decl::Assign { value, .. } => value,
+            _ => panic!("expected assignment"),
+        };
+        assert!(matches!(
+            u(value),
+            Expr::TypeExpr(TypeExpr::Named { name, args }) if name == "interface" && args.is_empty()
+        ));
     }
 
     #[test]

--- a/crates/aura-typecheck/src/aliases.rs
+++ b/crates/aura-typecheck/src/aliases.rs
@@ -29,6 +29,10 @@ impl TypeAliases {
             "Float".to_string(),
             TypeAlias::Concrete(interner.intern(Ty::Float32)),
         );
+        aliases.insert(
+            "Any".to_string(),
+            TypeAlias::Concrete(interner.intern(Ty::Interface(Vec::new()))),
+        );
         Self { aliases }
     }
 
@@ -88,6 +92,11 @@ mod tests {
 
         assert!(matches!(interner.get(int), Some(Ty::Int32)));
         assert!(matches!(interner.get(float), Some(Ty::Float32)));
+        let any = aliases.get("Any").expect("Any alias");
+        assert!(matches!(
+            interner.get(any),
+            Some(Ty::Interface(m)) if m.is_empty()
+        ));
         assert!(aliases.get("String").is_none());
     }
 }

--- a/crates/aura-typecheck/src/checker.rs
+++ b/crates/aura-typecheck/src/checker.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use aura_diagnostics::type_ref::FuncParamRef;
 use aura_diagnostics::{Diagnostic, Issue, PrimitiveType, Stage, TypeRef, TypingContext};
@@ -366,8 +366,14 @@ impl TypeChecker {
                 PrimitiveType::Char => self.interner.intern(Ty::Char),
                 PrimitiveType::Void => self.interner.intern(Ty::Void),
                 PrimitiveType::Never => self.interner.intern(Ty::Never),
-                PrimitiveType::Any => self.interner.intern(Ty::Any),
             },
+            TypeRef::Interface(members) => {
+                let fields = members
+                    .iter()
+                    .map(|(name, ty)| (name.clone(), self.type_ref_to_ty(ty)))
+                    .collect::<Vec<_>>();
+                self.interner.intern(Ty::Interface(fields))
+            }
             TypeRef::InferVar(v) => self.interner.intern(Ty::InferVar(*v)),
             TypeRef::GenericParam(name) => self.interner.intern(Ty::GenericParam(name.clone())),
             TypeRef::Nominal(name) => self.nominal_ty(name),
@@ -458,13 +464,6 @@ impl TypeChecker {
                     .map(|item| self.type_ref_to_ty(item))
                     .collect::<Vec<_>>();
                 self.interner.intern(Ty::Union(item_tys))
-            }
-            TypeRef::Interface(members) => {
-                let member_tys = members
-                    .iter()
-                    .map(|(name, ty)| (name.clone(), self.type_ref_to_ty(ty)))
-                    .collect::<Vec<_>>();
-                self.interner.intern(Ty::Interface(member_tys))
             }
             TypeRef::Enum(variants) => {
                 let lowered = variants
@@ -769,7 +768,11 @@ impl TypeChecker {
             self.typecheck_error(
                 Issue::TypeMismatch {
                     context: TypingContext::Custom("enum constructor".to_string()),
-                    expected: ty_to_ref(self.interner.get(enum_ty).unwrap_or(&Ty::Any), &self.interner),
+                    expected: self
+                        .interner
+                        .get(enum_ty)
+                        .map(|t| ty_to_ref(t, &self.interner))
+                        .unwrap_or(TypeRef::Unknown),
                     actual: TypeRef::Unknown,
                 },
                 format!("type mismatch in enum constructor: {reason}"),
@@ -1194,14 +1197,16 @@ impl TypeChecker {
                         self.typecheck_error(
                             Issue::TypeMismatch {
                                 context: TypingContext::Assignment,
-                                expected: ty_to_ref(
-                                    self.interner.get(binding.ty).unwrap_or(&Ty::Any),
-                                    &self.interner,
-                                ),
-                                actual: ty_to_ref(
-                                    self.interner.get(binding.ty).unwrap_or(&Ty::Any),
-                                    &self.interner,
-                                ),
+                                expected: self
+                                    .interner
+                                    .get(binding.ty)
+                                    .map(|t| ty_to_ref(t, &self.interner))
+                                    .unwrap_or(TypeRef::Unknown),
+                                actual: self
+                                    .interner
+                                    .get(binding.ty)
+                                    .map(|t| ty_to_ref(t, &self.interner))
+                                    .unwrap_or(TypeRef::Unknown),
                             },
                             format!("cannot assign through immutable local '{name}'"),
                         )
@@ -2418,10 +2423,11 @@ impl TypeChecker {
                                         context: TypingContext::Custom(
                                             "enum constructor".to_string(),
                                         ),
-                                        expected: ty_to_ref(
-                                            self.interner.get(enum_ty).unwrap_or(&Ty::Any),
-                                            &self.interner,
-                                        ),
+                                        expected: self
+                                            .interner
+                                            .get(enum_ty)
+                                            .map(|t| ty_to_ref(t, &self.interner))
+                                            .unwrap_or(TypeRef::Unknown),
                                         actual: TypeRef::Unknown,
                                     },
                                     format!(
@@ -3524,10 +3530,10 @@ impl TypeChecker {
             return self.unknown_ty();
         };
 
-        if matches!(lhs_ty, Ty::Any) {
+        if matches!(&lhs_ty, Ty::Interface(m) if m.is_empty()) {
             return rhs;
         }
-        if matches!(rhs_ty, Ty::Any) {
+        if matches!(&rhs_ty, Ty::Interface(m) if m.is_empty()) {
             return lhs;
         }
         if matches!(lhs_ty, Ty::Never) {
@@ -3619,13 +3625,26 @@ impl TypeChecker {
                 self.interner.intern(Ty::Struct(lowered))
             }
             TypeExpr::Interface(members) => {
-                if members.is_empty() {
-                    return self.interner.intern(Ty::Any);
-                }
-                let lowered = members
+                let mut lowered: Vec<(String, TyId)> = members
                     .iter()
                     .map(|(name, ty)| (name.clone(), self.resolve_type_expr(ty)))
-                    .collect::<Vec<_>>();
+                    .collect();
+                lowered.sort_by(|a, b| a.0.cmp(&b.0));
+                for w in lowered.windows(2) {
+                    if w[0].0 == w[1].0 {
+                        self.diagnostics.push(
+                            self.typecheck_error(
+                                Issue::InterfaceDuplicateMember {
+                                    name: w[0].0.clone(),
+                                },
+                                format!("duplicate interface member `{}`", w[0].0),
+                            )
+                            .with_stage(Stage::Typecheck)
+                            .with_hint("each interface member name must appear at most once"),
+                        );
+                        return self.unknown_ty();
+                    }
+                }
                 self.interner.intern(Ty::Interface(lowered))
             }
             TypeExpr::Named { name, args } => {
@@ -3691,7 +3710,7 @@ impl TypeChecker {
                         }
                     }
                     if members.is_empty() {
-                        return self.interner.intern(Ty::Any);
+                        return self.interner.intern(Ty::Interface(Vec::new()));
                     }
                     return self.interner.intern(Ty::Interface(members));
                 }
@@ -3774,10 +3793,6 @@ impl TypeChecker {
                     "Never" => {
                         self.enforce_exact_type_arity("Never", args, 0);
                         self.interner.intern(Ty::Never)
-                    }
-                    "Any" => {
-                        self.enforce_exact_type_arity("Any", args, 0);
-                        self.interner.intern(Ty::Any)
                     }
                     "Bytes" => {
                         self.enforce_exact_type_arity("Bytes", args, 0);
@@ -4853,12 +4868,12 @@ impl TypeChecker {
             return true;
         }
         if let Some(alias) = self.aliases.get(interface) {
-            return matches!(self.interner.get(alias), Some(Ty::Interface(_) | Ty::Any));
+            return matches!(self.interner.get(alias), Some(Ty::Interface(_)));
         }
         if let Some((static_params, body)) = self.aliases.get_generic(interface) {
             if static_params.is_empty() {
                 let ty = self.resolve_type_expr(&body);
-                return matches!(self.interner.get(ty), Some(Ty::Interface(_) | Ty::Any));
+                return matches!(self.interner.get(ty), Some(Ty::Interface(_)));
             }
         }
         false
@@ -4902,9 +4917,6 @@ impl TypeChecker {
             return None;
         };
         let Ty::Interface(required_methods) = interface else {
-            if matches!(interface, Ty::Any) {
-                return None;
-            }
             return Some(InterfaceCheckFailure::MissingMethod {
                 interface: self.interface_label(interface_expr),
                 method: "<not-an-interface>".to_string(),
@@ -4964,7 +4976,7 @@ impl TypeChecker {
 
     fn satisfies_prelude_interface(&self, ty: &Ty, interface: &str) -> bool {
         match interface {
-            "interface" => matches!(ty, Ty::Any | Ty::Interface(_)),
+            "interface" => true,
             "Eq" => matches!(
                 ty,
                 Ty::Bool
@@ -5062,7 +5074,7 @@ impl TypeChecker {
             return ConversionDecision::Incompatible;
         };
 
-        if matches!(expected_ty, Ty::Any) {
+        if matches!(&expected_ty, Ty::Interface(m) if m.is_empty()) {
             return ConversionDecision::Identity;
         }
 
@@ -5073,6 +5085,12 @@ impl TypeChecker {
 
         if matches!(actual_ty, Ty::Never) {
             return ConversionDecision::Identity;
+        }
+
+        if let (Ty::Interface(_), Ty::Interface(_)) = (&expected_ty, &actual_ty) {
+            if self.structurally_equivalent(expected, actual) {
+                return ConversionDecision::Identity;
+            }
         }
 
         if matches!(expected_ty, Ty::Interface(_)) {
@@ -5213,8 +5231,32 @@ impl TypeChecker {
                         .all(|(x, y)| self.structurally_equivalent(x.ty, y.ty))
                     && self.structurally_equivalent(*ar, *br)
             }
+            (Ty::Interface(a), Ty::Interface(b)) => {
+                self.interface_member_sets_equivalent(a, b)
+            }
             _ => false,
         }
+    }
+
+    fn interface_member_sets_equivalent(
+        &self,
+        a: &[(String, TyId)],
+        b: &[(String, TyId)],
+    ) -> bool {
+        if a.len() != b.len() {
+            return false;
+        }
+        let names_a: HashSet<&str> = a.iter().map(|(n, _)| n.as_str()).collect();
+        let names_b: HashSet<&str> = b.iter().map(|(n, _)| n.as_str()).collect();
+        if names_a != names_b {
+            return false;
+        }
+        let map_b: HashMap<&str, TyId> = b.iter().map(|(n, t)| (n.as_str(), *t)).collect();
+        a.iter().all(|(name, ta)| {
+            map_b
+                .get(name.as_str())
+                .is_some_and(|tb| self.structurally_equivalent(*ta, *tb))
+        })
     }
 
     fn emit_type_mismatch(&mut self, expected: TyId, actual: TyId, context: &str, related: &str) {
@@ -6398,7 +6440,6 @@ fn ty_to_ref(ty: &Ty, interner: &TyInterner) -> TypeRef {
         Ty::Char => TypeRef::Primitive(PrimitiveType::Char),
         Ty::Void => TypeRef::Primitive(PrimitiveType::Void),
         Ty::Never => TypeRef::Primitive(PrimitiveType::Never),
-        Ty::Any => TypeRef::Primitive(PrimitiveType::Any),
         Ty::Nominal(name) => TypeRef::Nominal(name.clone()),
         Ty::RawAlloc(item) => TypeRef::RawAlloc(Box::new(
             interner
@@ -9340,7 +9381,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_interface_annotation_resolves_as_any_type() {
+    fn empty_interface_annotation_resolves_to_empty_interface_ty() {
         let src = r#"
             def x: interface() = 1
         "#;
@@ -9348,7 +9389,10 @@ mod tests {
         let checked = check_module(&parsed);
         let module = checked.module.expect("module should exist");
         let x_ty = module.value_types.get("x").copied().expect("x should be typed");
-        assert!(matches!(module.types.get(x_ty), Some(Ty::Any)));
+        assert!(matches!(
+            module.types.get(x_ty),
+            Some(Ty::Interface(m)) if m.is_empty()
+        ));
     }
 
     #[test]

--- a/crates/aura-typecheck/src/types.rs
+++ b/crates/aura-typecheck/src/types.rs
@@ -54,7 +54,8 @@ pub enum Ty {
     Char,
     Void,
     Never,
-    Any,
+    /// Structural interface type: empty `interface()` is the universal top type (stdlib `Any`).
+    Interface(Vec<(String, TyId)>),
     Nominal(String),
     RawAlloc(TyId),
     Slice(TyId),
@@ -68,7 +69,6 @@ pub enum Ty {
     Tuple(Vec<TyId>),
     Struct(Vec<(String, TyId)>),
     Union(Vec<TyId>),
-    Interface(Vec<(String, TyId)>),
     InterfaceObject(Vec<(String, TyId)>),
     Enum(Vec<(String, Option<TyId>)>),
 }
@@ -85,6 +85,13 @@ impl TyInterner {
     }
 
     pub fn intern(&mut self, ty: Ty) -> TyId {
+        let ty = match ty {
+            Ty::Interface(mut members) => {
+                members.sort_by(|a, b| a.0.cmp(&b.0));
+                Ty::Interface(members)
+            }
+            other => other,
+        };
         if let Some(id) = self.index.get(&ty) {
             return *id;
         }
@@ -118,7 +125,6 @@ impl TyInterner {
             char_: self.intern(Ty::Char),
             void: self.intern(Ty::Void),
             never: self.intern(Ty::Never),
-            any: self.intern(Ty::Any),
         }
     }
 
@@ -149,7 +155,6 @@ pub struct PreludeTypeIds {
     pub char_: TyId,
     pub void: TyId,
     pub never: TyId,
-    pub any: TyId,
 }
 
 #[cfg(test)]

--- a/crates/aura-typecheck/src/unify.rs
+++ b/crates/aura-typecheck/src/unify.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::types::{FuncParam, Ty, TyId, TyInterner};
 use aura_diagnostics::{Diagnostic, Issue};
@@ -40,8 +40,41 @@ impl Unifier {
         let rhs_ty = interner.get(rhs).cloned();
 
         match (lhs_ty, rhs_ty) {
-            (Some(Ty::Any), Some(_)) => Ok(rhs),
-            (Some(_), Some(Ty::Any)) => Ok(lhs),
+            (Some(Ty::Interface(m)), Some(_)) if m.is_empty() => Ok(rhs),
+            (Some(_), Some(Ty::Interface(m))) if m.is_empty() => Ok(lhs),
+            (Some(Ty::Interface(a)), Some(Ty::Interface(b))) if !a.is_empty() && !b.is_empty() => {
+                if a.len() != b.len() {
+                    return Err(Box::new(
+                        Diagnostic::error(Issue::UnifyMismatch)
+                            .with_related("interface member count differs", None)
+                            .with_hint("use interfaces with the same method set for this constraint"),
+                    ));
+                }
+                let names_a: HashSet<_> = a.iter().map(|(n, _)| n).collect();
+                let names_b: HashSet<_> = b.iter().map(|(n, _)| n).collect();
+                if names_a != names_b {
+                    return Err(Box::new(
+                        Diagnostic::error(Issue::UnifyMismatch)
+                            .with_related("interface member name sets differ", None)
+                            .with_hint("interfaces unify by member name, not declaration order"),
+                    ));
+                }
+                let map_b: HashMap<_, _> = b.iter().map(|(n, t)| (n.clone(), *t)).collect();
+                let mut members = Vec::with_capacity(a.len());
+                for (name, ty_a) in a {
+                    let Some(ty_b) = map_b.get(&name).copied() else {
+                        return Err(Box::new(
+                            Diagnostic::error(Issue::UnifyMismatch)
+                                .with_related("interface member name missing on right-hand side", None)
+                                .with_hint("interfaces unify by member name, not declaration order"),
+                        ));
+                    };
+                    let ty = self.unify(interner, ty_a, ty_b, _context)?;
+                    members.push((name.clone(), ty));
+                }
+                members.sort_by(|x, y| x.0.cmp(&y.0));
+                Ok(interner.intern(Ty::Interface(members)))
+            }
             (Some(Ty::GenericParam(a)), Some(Ty::GenericParam(b))) if a == b => Ok(lhs),
             (Some(Ty::InferVar(_)), Some(_)) => {
                 if self.occurs(interner, lhs, rhs) {
@@ -325,6 +358,9 @@ impl Unifier {
             Some(Ty::Enum(variants)) => variants
                 .iter()
                 .any(|(_, payload)| payload.is_some_and(|t| self.occurs(interner, var, t))),
+            Some(Ty::Interface(members)) => members
+                .iter()
+                .any(|(_, ty)| self.occurs(interner, var, *ty)),
             _ => false,
         }
     }
@@ -436,5 +472,26 @@ mod tests {
             .unify(&mut interner, a4, a8, "array mismatch")
             .expect_err("array size mismatch should fail");
         assert_eq!(err.code_str(), "E_UNIFY_MISMATCH");
+    }
+
+    #[test]
+    fn interface_intern_canonicalizes_member_order() {
+        let mut interner = TyInterner::new();
+        let mut unifier = Unifier::new();
+        let int = interner.intern(Ty::Int32);
+        let float = interner.intern(Ty::Float32);
+        let a = interner.intern(Ty::Interface(vec![
+            ("b".to_string(), float),
+            ("a".to_string(), int),
+        ]));
+        let b = interner.intern(Ty::Interface(vec![
+            ("a".to_string(), int),
+            ("b".to_string(), float),
+        ]));
+        assert_eq!(a, b);
+        let unified = unifier
+            .unify(&mut interner, a, b, "iface")
+            .expect("interface types with same members unify");
+        assert_eq!(unified, a);
     }
 }

--- a/docs/.obsidian/workspace.json
+++ b/docs/.obsidian/workspace.json
@@ -4,21 +4,21 @@
     "type": "split",
     "children": [
       {
-        "id": "1912ece4e3aebe6a",
+        "id": "9105efaab6785706",
         "type": "tabs",
         "children": [
           {
-            "id": "64d3a652f7f86ae7",
+            "id": "120d29afefd7d451",
             "type": "leaf",
             "state": {
               "type": "markdown",
               "state": {
-                "file": "Home.md",
+                "file": "Language/Syntax And Semantics.md",
                 "mode": "source",
                 "source": false
               },
               "icon": "lucide-file",
-              "title": "Home"
+              "title": "Syntax And Semantics"
             }
           }
         ]
@@ -180,9 +180,13 @@
       "bases:Criar nova base": false
     }
   },
-  "active": "64d3a652f7f86ae7",
+  "active": "120d29afefd7d451",
   "lastOpenFiles": [
     "_meta/taxonomy.md",
+    "_meta",
+    "Language/AUON.md",
+    "Language/Examples Index.md",
+    "Language/Design Overview.md",
     "Home.md",
     "hot.md",
     "log.md",
@@ -198,7 +202,6 @@
     "Subsystems/Xtask.md",
     "Subsystems/Runtime Host.md",
     "Subsystems/Diagnostics.md",
-    "Language/AUON.md",
     "Bases/Subsystems.base",
     "Bases/Decisions.base",
     "Contracts/Typecheck IR.md",
@@ -207,9 +210,6 @@
     "Generated/Examples Inventory.md",
     "Generated/Directory Inventory.md",
     "Generated/Commands Inventory.md",
-    "Language/Examples Index.md",
-    "Language/Syntax And Semantics.md",
-    "Language/Design Overview.md",
-    "Subsystems/CLI.md"
+    "Language/Syntax And Semantics.md"
   ]
 }


### PR DESCRIPTION
## Summary
Removes the built-in `Ty::Any` / `PrimitiveType::Any` path and models the top type as `Ty::Interface([])` with a first-class `interface(...)` type expression.

The name `Any` is defined in the standard library (`aura-stl`) and the compiler also pre-registers the same alias (like `Int`/`Float`) so single-file programs keep working.

## Submodule
- **aura-stl:** https://github.com/nahharris/aura-stl/pull/3 — adds `src/any.aura` and `use (Any) = "any"` in `lib.aura`.
- This PR bumps the `aura-stl` gitlink to that branch until the STL PR merges (then re-point to merged `master` if needed).

## Test plan
- [x] `cargo xtask dev check`
- [x] `cargo xtask dev test`
